### PR TITLE
Change ArticleId to ResourcePrimaryKey

### DIFF
--- a/modules/common-utils/src/main/java/nl/deltares/portal/model/DsdArticle.java
+++ b/modules/common-utils/src/main/java/nl/deltares/portal/model/DsdArticle.java
@@ -9,8 +9,8 @@ public interface DsdArticle {
     enum DSD_STRUCTURE_KEYS {Expert, Location, Building, Room, Eventlocation, Registration, Session, Bustransfer, Dinner}
     String getTitle();
     long getCompanyId();
-    long getArticleId();
     long getGroupId();
+    long getResourceId();
     String getStructureKey();
     Document getDocument();
     boolean storeInParentSite();

--- a/modules/common-utils/src/main/java/nl/deltares/portal/model/impl/AbsDsdArticle.java
+++ b/modules/common-utils/src/main/java/nl/deltares/portal/model/impl/AbsDsdArticle.java
@@ -21,17 +21,13 @@ public abstract class AbsDsdArticle implements DsdArticle {
     }
 
     @Override
-    public String getTitle() {
-        return article.getTitle();
+    public long getResourceId() {
+        return article.getResourcePrimKey();
     }
 
     @Override
-    public long getArticleId(){
-        String articleId = article.getArticleId();
-        if (articleId.startsWith("/")){
-            return Long.parseLong(articleId.substring(1));
-        }
-        return Long.parseLong(articleId);
+    public String getTitle() {
+        return article.getTitle();
     }
 
     @Override
@@ -58,7 +54,7 @@ public abstract class AbsDsdArticle implements DsdArticle {
         try {
             this.document = XmlContentParserUtils.parseContent(article);
         } catch (Exception e) {
-            throw new PortalException(String.format("Error parsing content for article %s: %s!", article.getArticleId(), e.getMessage()), e);
+            throw new PortalException(String.format("Error parsing content for article %s: %s!", article.getTitle(), e.getMessage()), e);
         }
     }
 

--- a/modules/common-utils/src/main/java/nl/deltares/portal/utils/impl/DsdRegistrationUtilsImpl.java
+++ b/modules/common-utils/src/main/java/nl/deltares/portal/utils/impl/DsdRegistrationUtilsImpl.java
@@ -33,7 +33,7 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
 
     @Override
     public void deleteRegistrationsFor(Registration registration) {
-        RegistrationLocalServiceUtil.deleteAllRegistrationsAndChildRegistrations(registration.getGroupId(), registration.getArticleId());
+        RegistrationLocalServiceUtil.deleteAllRegistrationsAndChildRegistrations(registration.getGroupId(), registration.getResourceId());
     }
 
     @Override
@@ -41,9 +41,9 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
 
         validateRegistration(user, registration);
 
-        long parentId = registration.getParentRegistration() == null ? 0 : registration.getParentRegistration().getArticleId();
+        long parentId = registration.getParentRegistration() == null ? 0 : registration.getParentRegistration().getResourceId();
         RegistrationLocalServiceUtil.addUserRegistration(
-                registration.getCompanyId(), registration.getGroupId(), registration.getArticleId(),
+                registration.getCompanyId(), registration.getGroupId(), registration.getResourceId(),
                 parentId, user.getUserId(),
                 registration.getStartTime(), registration.getEndTime(), userProperties);
     }
@@ -52,7 +52,7 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
     public void unRegisterUser(User user, Registration registration) {
 
         RegistrationLocalServiceUtil.deleteUserRegistrationAndChildRegistrations(
-                registration.getGroupId(), registration.getArticleId(), user.getUserId());
+                registration.getGroupId(), registration.getResourceId(), user.getUserId());
     }
 
     @Override
@@ -87,7 +87,7 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
 
     @Override
     public int getRegistrationCount(Registration registration) {
-        return RegistrationLocalServiceUtil.getRegistrationsCount(registration.getGroupId(), registration.getArticleId());
+        return RegistrationLocalServiceUtil.getRegistrationsCount(registration.getGroupId(), registration.getResourceId());
     }
 
     private long[] getOverlappingRegistrationIds(User user, Registration registration){
@@ -100,7 +100,7 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
         if (registrationsWithOverlappingPeriod.length == 0 || registration.getParentRegistration() == null) {
             return registrationsWithOverlappingPeriod;
         }
-        long parentId = registration.getParentRegistration().getArticleId();
+        long parentId = registration.getParentRegistration().getResourceId();
         boolean overlapWithParent = registration.isOverlapWithParent();
 
         for (int i = 0; i < registrationsWithOverlappingPeriod.length; i++) {
@@ -113,12 +113,12 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
 
     @Override
     public List<Registration> getOverlappingRegistrations(User user, Registration registration) throws PortalException {
-        long[] overlappingArticleId = RegistrationLocalServiceUtil.getRegistrationsWithOverlappingPeriod(registration.getGroupId(), user.getUserId(),
+        long[] overlappingResourceIds = RegistrationLocalServiceUtil.getRegistrationsWithOverlappingPeriod(registration.getGroupId(), user.getUserId(),
                 registration.getStartTime(), registration.getEndTime());
 
         ArrayList<Registration> overlapping = new ArrayList<>();
-        for (long articleId : overlappingArticleId) {
-            JournalArticle overlappingArticle = JournalArticleLocalServiceUtil.getLatestArticle(registration.getGroupId(), String.valueOf(articleId));
+        for (long resourceId : overlappingResourceIds) {
+            JournalArticle overlappingArticle = JournalArticleLocalServiceUtil.getLatestArticle(resourceId);
             overlapping.add((Registration) AbsDsdArticle.getInstance(overlappingArticle));
         }
         return overlapping;
@@ -170,7 +170,7 @@ public class DsdRegistrationUtilsImpl implements DsdRegistrationUtils{
 
     @Override
     public boolean isUserRegisteredFor(User user, Registration registration) {
-        int registrationsCount = RegistrationLocalServiceUtil.getRegistrationsCount(registration.getGroupId(), user.getUserId(), registration.getArticleId());
+        int registrationsCount = RegistrationLocalServiceUtil.getRegistrationsCount(registration.getGroupId(), user.getUserId(), registration.getResourceId());
         return registrationsCount > 0;
     }
 }

--- a/modules/journal-article-listener/src/main/java/nl/worth/fews/model/listener/JournalArticleListener.java
+++ b/modules/journal-article-listener/src/main/java/nl/worth/fews/model/listener/JournalArticleListener.java
@@ -48,7 +48,7 @@ public class JournalArticleListener extends BaseModelListener<JournalArticle> {
     private static final Log LOGGER = LogFactoryUtil.getLog(JournalArticleListener.class);
 
     @Override
-    public void onAfterRemove(JournalArticle model) throws ModelListenerException {
+    public void onBeforeRemove(JournalArticle model) throws ModelListenerException {
 
         //When removing an article clean up records in registrations table.
         if (AbsDsdArticle.isDsdArticle(model)) {

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/model/RegistrationModel.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/model/RegistrationModel.java
@@ -135,18 +135,18 @@ public interface RegistrationModel
 	public void setUserUuid(String userUuid);
 
 	/**
-	 * Returns the article ID of this registration.
+	 * Returns the resource primary key of this registration.
 	 *
-	 * @return the article ID of this registration
+	 * @return the resource primary key of this registration
 	 */
-	public long getArticleId();
+	public long getResourcePrimaryKey();
 
 	/**
-	 * Sets the article ID of this registration.
+	 * Sets the resource primary key of this registration.
 	 *
-	 * @param articleId the article ID of this registration
+	 * @param resourcePrimaryKey the resource primary key of this registration
 	 */
-	public void setArticleId(long articleId);
+	public void setResourcePrimaryKey(long resourcePrimaryKey);
 
 	/**
 	 * Returns the user preferences of this registration.
@@ -192,18 +192,18 @@ public interface RegistrationModel
 	public void setEndTime(Date endTime);
 
 	/**
-	 * Returns the parent article ID of this registration.
+	 * Returns the parent resource primary key of this registration.
 	 *
-	 * @return the parent article ID of this registration
+	 * @return the parent resource primary key of this registration
 	 */
-	public long getParentArticleId();
+	public long getParentResourcePrimaryKey();
 
 	/**
-	 * Sets the parent article ID of this registration.
+	 * Sets the parent resource primary key of this registration.
 	 *
-	 * @param parentArticleId the parent article ID of this registration
+	 * @param parentResourcePrimaryKey the parent resource primary key of this registration
 	 */
-	public void setParentArticleId(long parentArticleId);
+	public void setParentResourcePrimaryKey(long parentResourcePrimaryKey);
 
 	@Override
 	public boolean isNew();

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/model/RegistrationSoap.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/model/RegistrationSoap.java
@@ -38,11 +38,12 @@ public class RegistrationSoap implements Serializable {
 		soapModel.setGroupId(model.getGroupId());
 		soapModel.setCompanyId(model.getCompanyId());
 		soapModel.setUserId(model.getUserId());
-		soapModel.setArticleId(model.getArticleId());
+		soapModel.setResourcePrimaryKey(model.getResourcePrimaryKey());
 		soapModel.setUserPreferences(model.getUserPreferences());
 		soapModel.setStartTime(model.getStartTime());
 		soapModel.setEndTime(model.getEndTime());
-		soapModel.setParentArticleId(model.getParentArticleId());
+		soapModel.setParentResourcePrimaryKey(
+			model.getParentResourcePrimaryKey());
 
 		return soapModel;
 	}
@@ -128,12 +129,12 @@ public class RegistrationSoap implements Serializable {
 		_userId = userId;
 	}
 
-	public long getArticleId() {
-		return _articleId;
+	public long getResourcePrimaryKey() {
+		return _resourcePrimaryKey;
 	}
 
-	public void setArticleId(long articleId) {
-		_articleId = articleId;
+	public void setResourcePrimaryKey(long resourcePrimaryKey) {
+		_resourcePrimaryKey = resourcePrimaryKey;
 	}
 
 	public String getUserPreferences() {
@@ -160,22 +161,22 @@ public class RegistrationSoap implements Serializable {
 		_endTime = endTime;
 	}
 
-	public long getParentArticleId() {
-		return _parentArticleId;
+	public long getParentResourcePrimaryKey() {
+		return _parentResourcePrimaryKey;
 	}
 
-	public void setParentArticleId(long parentArticleId) {
-		_parentArticleId = parentArticleId;
+	public void setParentResourcePrimaryKey(long parentResourcePrimaryKey) {
+		_parentResourcePrimaryKey = parentResourcePrimaryKey;
 	}
 
 	private long _registrationId;
 	private long _groupId;
 	private long _companyId;
 	private long _userId;
-	private long _articleId;
+	private long _resourcePrimaryKey;
 	private String _userPreferences;
 	private Date _startTime;
 	private Date _endTime;
-	private long _parentArticleId;
+	private long _parentResourcePrimaryKey;
 
 }

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/model/RegistrationWrapper.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/model/RegistrationWrapper.java
@@ -62,11 +62,12 @@ public class RegistrationWrapper
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
 		attributes.put("userId", getUserId());
-		attributes.put("articleId", getArticleId());
+		attributes.put("resourcePrimaryKey", getResourcePrimaryKey());
 		attributes.put("userPreferences", getUserPreferences());
 		attributes.put("startTime", getStartTime());
 		attributes.put("endTime", getEndTime());
-		attributes.put("parentArticleId", getParentArticleId());
+		attributes.put(
+			"parentResourcePrimaryKey", getParentResourcePrimaryKey());
 
 		return attributes;
 	}
@@ -97,10 +98,10 @@ public class RegistrationWrapper
 			setUserId(userId);
 		}
 
-		Long articleId = (Long)attributes.get("articleId");
+		Long resourcePrimaryKey = (Long)attributes.get("resourcePrimaryKey");
 
-		if (articleId != null) {
-			setArticleId(articleId);
+		if (resourcePrimaryKey != null) {
+			setResourcePrimaryKey(resourcePrimaryKey);
 		}
 
 		String userPreferences = (String)attributes.get("userPreferences");
@@ -121,10 +122,11 @@ public class RegistrationWrapper
 			setEndTime(endTime);
 		}
 
-		Long parentArticleId = (Long)attributes.get("parentArticleId");
+		Long parentResourcePrimaryKey = (Long)attributes.get(
+			"parentResourcePrimaryKey");
 
-		if (parentArticleId != null) {
-			setParentArticleId(parentArticleId);
+		if (parentResourcePrimaryKey != null) {
+			setParentResourcePrimaryKey(parentResourcePrimaryKey);
 		}
 	}
 
@@ -138,16 +140,6 @@ public class RegistrationWrapper
 		nl.deltares.dsd.registration.model.Registration registration) {
 
 		return _registration.compareTo(registration);
-	}
-
-	/**
-	 * Returns the article ID of this registration.
-	 *
-	 * @return the article ID of this registration
-	 */
-	@Override
-	public long getArticleId() {
-		return _registration.getArticleId();
 	}
 
 	/**
@@ -186,13 +178,13 @@ public class RegistrationWrapper
 	}
 
 	/**
-	 * Returns the parent article ID of this registration.
+	 * Returns the parent resource primary key of this registration.
 	 *
-	 * @return the parent article ID of this registration
+	 * @return the parent resource primary key of this registration
 	 */
 	@Override
-	public long getParentArticleId() {
-		return _registration.getParentArticleId();
+	public long getParentResourcePrimaryKey() {
+		return _registration.getParentResourcePrimaryKey();
 	}
 
 	/**
@@ -218,6 +210,16 @@ public class RegistrationWrapper
 	@Override
 	public long getRegistrationId() {
 		return _registration.getRegistrationId();
+	}
+
+	/**
+	 * Returns the resource primary key of this registration.
+	 *
+	 * @return the resource primary key of this registration
+	 */
+	@Override
+	public long getResourcePrimaryKey() {
+		return _registration.getResourcePrimaryKey();
 	}
 
 	/**
@@ -285,16 +287,6 @@ public class RegistrationWrapper
 		_registration.persist();
 	}
 
-	/**
-	 * Sets the article ID of this registration.
-	 *
-	 * @param articleId the article ID of this registration
-	 */
-	@Override
-	public void setArticleId(long articleId) {
-		_registration.setArticleId(articleId);
-	}
-
 	@Override
 	public void setCachedModel(boolean cachedModel) {
 		_registration.setCachedModel(cachedModel);
@@ -353,13 +345,13 @@ public class RegistrationWrapper
 	}
 
 	/**
-	 * Sets the parent article ID of this registration.
+	 * Sets the parent resource primary key of this registration.
 	 *
-	 * @param parentArticleId the parent article ID of this registration
+	 * @param parentResourcePrimaryKey the parent resource primary key of this registration
 	 */
 	@Override
-	public void setParentArticleId(long parentArticleId) {
-		_registration.setParentArticleId(parentArticleId);
+	public void setParentResourcePrimaryKey(long parentResourcePrimaryKey) {
+		_registration.setParentResourcePrimaryKey(parentResourcePrimaryKey);
 	}
 
 	/**
@@ -385,6 +377,16 @@ public class RegistrationWrapper
 	@Override
 	public void setRegistrationId(long registrationId) {
 		_registration.setRegistrationId(registrationId);
+	}
+
+	/**
+	 * Sets the resource primary key of this registration.
+	 *
+	 * @param resourcePrimaryKey the resource primary key of this registration
+	 */
+	@Override
+	public void setResourcePrimaryKey(long resourcePrimaryKey) {
+		_registration.setResourcePrimaryKey(resourcePrimaryKey);
 	}
 
 	/**

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/RegistrationLocalService.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/RegistrationLocalService.java
@@ -15,6 +15,8 @@
 package nl.deltares.dsd.registration.service;
 
 import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.kernel.dao.orm.*;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
@@ -30,11 +32,13 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import nl.deltares.dsd.registration.model.Registration;
 
 import java.io.Serializable;
+
 import java.util.Date;
 import java.util.List;
+
+import nl.deltares.dsd.registration.model.Registration;
 
 /**
  * Provides the local service interface for Registration. Methods of this
@@ -70,7 +74,7 @@ public interface RegistrationLocalService
 	public Registration addRegistration(Registration registration);
 
 	public void addUserRegistration(
-		long companyId, long groupId, long articleId, long parentArticleId,
+		long companyId, long groupId, long resouceId, long parentResourceId,
 		long userId, Date startTime, Date endTime, String preferences);
 
 	/**
@@ -83,14 +87,14 @@ public interface RegistrationLocalService
 	public Registration createRegistration(long registrationId);
 
 	/**
-	 * Delete all registrations related to 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete all registrations related to 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 *
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 */
 	public void deleteAllRegistrationsAndChildRegistrations(
-		long groupId, long articleId);
+		long groupId, long resourceId);
 
 	/**
 	 * @throws PortalException
@@ -120,15 +124,15 @@ public interface RegistrationLocalService
 	public Registration deleteRegistration(Registration registration);
 
 	/**
-	 * Delete user registrations for 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete user registrations for 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 *
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 * @param userId User for which to remove registration
 	 */
 	public void deleteUserRegistrationAndChildRegistrations(
-		long groupId, long articleId, long userId);
+		long groupId, long resourceId, long userId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DynamicQuery dynamicQuery();
@@ -251,10 +255,11 @@ public interface RegistrationLocalService
 	public int getRegistrationsCount();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getRegistrationsCount(long groupId, long articleId);
+	public int getRegistrationsCount(long groupId, long resourceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getRegistrationsCount(long groupId, long userId, long articleId);
+	public int getRegistrationsCount(
+		long groupId, long userId, long resourceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long[] getRegistrationsWithOverlappingPeriod(

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/RegistrationLocalServiceUtil.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/RegistrationLocalServiceUtil.java
@@ -55,12 +55,12 @@ public class RegistrationLocalServiceUtil {
 	}
 
 	public static void addUserRegistration(
-		long companyId, long groupId, long articleId, long parentArticleId,
+		long companyId, long groupId, long resouceId, long parentResourceId,
 		long userId, java.util.Date startTime, java.util.Date endTime,
 		String preferences) {
 
 		getService().addUserRegistration(
-			companyId, groupId, articleId, parentArticleId, userId, startTime,
+			companyId, groupId, resouceId, parentResourceId, userId, startTime,
 			endTime, preferences);
 	}
 
@@ -77,17 +77,17 @@ public class RegistrationLocalServiceUtil {
 	}
 
 	/**
-	 * Delete all registrations related to 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete all registrations related to 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 *
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 */
 	public static void deleteAllRegistrationsAndChildRegistrations(
-		long groupId, long articleId) {
+		long groupId, long resourceId) {
 
 		getService().deleteAllRegistrationsAndChildRegistrations(
-			groupId, articleId);
+			groupId, resourceId);
 	}
 
 	/**
@@ -129,18 +129,18 @@ public class RegistrationLocalServiceUtil {
 	}
 
 	/**
-	 * Delete user registrations for 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete user registrations for 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 *
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 * @param userId User for which to remove registration
 	 */
 	public static void deleteUserRegistrationAndChildRegistrations(
-		long groupId, long articleId, long userId) {
+		long groupId, long resourceId, long userId) {
 
 		getService().deleteUserRegistrationAndChildRegistrations(
-			groupId, articleId, userId);
+			groupId, resourceId, userId);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.DynamicQuery
@@ -304,14 +304,14 @@ public class RegistrationLocalServiceUtil {
 		return getService().getRegistrationsCount();
 	}
 
-	public static int getRegistrationsCount(long groupId, long articleId) {
-		return getService().getRegistrationsCount(groupId, articleId);
+	public static int getRegistrationsCount(long groupId, long resourceId) {
+		return getService().getRegistrationsCount(groupId, resourceId);
 	}
 
 	public static int getRegistrationsCount(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourceId) {
 
-		return getService().getRegistrationsCount(groupId, userId, articleId);
+		return getService().getRegistrationsCount(groupId, userId, resourceId);
 	}
 
 	public static long[] getRegistrationsWithOverlappingPeriod(

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/RegistrationLocalServiceWrapper.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/RegistrationLocalServiceWrapper.java
@@ -51,12 +51,12 @@ public class RegistrationLocalServiceWrapper
 
 	@Override
 	public void addUserRegistration(
-		long companyId, long groupId, long articleId, long parentArticleId,
+		long companyId, long groupId, long resouceId, long parentResourceId,
 		long userId, java.util.Date startTime, java.util.Date endTime,
 		String preferences) {
 
 		_registrationLocalService.addUserRegistration(
-			companyId, groupId, articleId, parentArticleId, userId, startTime,
+			companyId, groupId, resouceId, parentResourceId, userId, startTime,
 			endTime, preferences);
 	}
 
@@ -74,18 +74,18 @@ public class RegistrationLocalServiceWrapper
 	}
 
 	/**
-	 * Delete all registrations related to 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete all registrations related to 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 *
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 */
 	@Override
 	public void deleteAllRegistrationsAndChildRegistrations(
-		long groupId, long articleId) {
+		long groupId, long resourceId) {
 
 		_registrationLocalService.deleteAllRegistrationsAndChildRegistrations(
-			groupId, articleId);
+			groupId, resourceId);
 	}
 
 	/**
@@ -128,19 +128,19 @@ public class RegistrationLocalServiceWrapper
 	}
 
 	/**
-	 * Delete user registrations for 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete user registrations for 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 *
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 * @param userId User for which to remove registration
 	 */
 	@Override
 	public void deleteUserRegistrationAndChildRegistrations(
-		long groupId, long articleId, long userId) {
+		long groupId, long resourceId, long userId) {
 
 		_registrationLocalService.deleteUserRegistrationAndChildRegistrations(
-			groupId, articleId, userId);
+			groupId, resourceId, userId);
 	}
 
 	@Override
@@ -316,17 +316,17 @@ public class RegistrationLocalServiceWrapper
 	}
 
 	@Override
-	public int getRegistrationsCount(long groupId, long articleId) {
+	public int getRegistrationsCount(long groupId, long resourceId) {
 		return _registrationLocalService.getRegistrationsCount(
-			groupId, articleId);
+			groupId, resourceId);
 	}
 
 	@Override
 	public int getRegistrationsCount(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourceId) {
 
 		return _registrationLocalService.getRegistrationsCount(
-			groupId, userId, articleId);
+			groupId, userId, resourceId);
 	}
 
 	@Override

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/persistence/RegistrationPersistence.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/persistence/RegistrationPersistence.java
@@ -205,59 +205,59 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	public int countByUserRegistrations(long groupId, long userId);
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the matching registrations
 	 */
 	public java.util.List<Registration> findByArticleRegistrations(
-		long groupId, long articleId);
+		long groupId, long resourcePrimaryKey);
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public java.util.List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end);
+		long groupId, long resourcePrimaryKey, int start, int end);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end,
+		long groupId, long resourcePrimaryKey, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -265,113 +265,115 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end,
+		long groupId, long resourcePrimaryKey, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator,
 		boolean retrieveFromCache);
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByArticleRegistrations_First(
-			long groupId, long articleId,
+			long groupId, long resourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByArticleRegistrations_First(
-		long groupId, long articleId,
+		long groupId, long resourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByArticleRegistrations_Last(
-			long groupId, long articleId,
+			long groupId, long resourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByArticleRegistrations_Last(
-		long groupId, long articleId,
+		long groupId, long resourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public Registration[] findByArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long articleId,
+			long registrationId, long groupId, long resourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and articleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and resourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 */
-	public void removeByArticleRegistrations(long groupId, long articleId);
+	public void removeByArticleRegistrations(
+		long groupId, long resourcePrimaryKey);
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the number of matching registrations
 	 */
-	public int countByArticleRegistrations(long groupId, long articleId);
+	public int countByArticleRegistrations(
+		long groupId, long resourcePrimaryKey);
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the matching registrations
 	 */
 	public java.util.List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId);
+		long groupId, long userId, long resourcePrimaryKey);
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -379,16 +381,16 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public java.util.List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end);
+		long groupId, long userId, long resourcePrimaryKey, int start, int end);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -396,19 +398,19 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end,
+		long groupId, long userId, long resourcePrimaryKey, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -416,7 +418,7 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -424,122 +426,123 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end,
+		long groupId, long userId, long resourcePrimaryKey, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator,
 		boolean retrieveFromCache);
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByUserArticleRegistrations_First(
-			long groupId, long userId, long articleId,
+			long groupId, long userId, long resourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByUserArticleRegistrations_First(
-		long groupId, long userId, long articleId,
+		long groupId, long userId, long resourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByUserArticleRegistrations_Last(
-			long groupId, long userId, long articleId,
+			long groupId, long userId, long resourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByUserArticleRegistrations_Last(
-		long groupId, long userId, long articleId,
+		long groupId, long userId, long resourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public Registration[] findByUserArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long userId, long articleId,
+			long registrationId, long groupId, long userId,
+			long resourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 */
 	public void removeByUserArticleRegistrations(
-		long groupId, long userId, long articleId);
+		long groupId, long userId, long resourcePrimaryKey);
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the number of matching registrations
 	 */
 	public int countByUserArticleRegistrations(
-		long groupId, long userId, long articleId);
+		long groupId, long userId, long resourcePrimaryKey);
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the matching registrations
 	 */
 	public java.util.List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId);
+		long groupId, long userId, long parentResourcePrimaryKey);
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -547,16 +550,17 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public java.util.List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end);
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -564,19 +568,20 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end,
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -584,7 +589,7 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -592,164 +597,165 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end,
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator,
 		boolean retrieveFromCache);
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByUserChildArticleRegistrations_First(
-			long groupId, long userId, long parentArticleId,
+			long groupId, long userId, long parentResourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByUserChildArticleRegistrations_First(
-		long groupId, long userId, long parentArticleId,
+		long groupId, long userId, long parentResourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByUserChildArticleRegistrations_Last(
-			long groupId, long userId, long parentArticleId,
+			long groupId, long userId, long parentResourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByUserChildArticleRegistrations_Last(
-		long groupId, long userId, long parentArticleId,
+		long groupId, long userId, long parentResourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public Registration[] findByUserChildArticleRegistrations_PrevAndNext(
 			long registrationId, long groupId, long userId,
-			long parentArticleId,
+			long parentResourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 */
 	public void removeByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId);
+		long groupId, long userId, long parentResourcePrimaryKey);
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the number of matching registrations
 	 */
 	public int countByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId);
+		long groupId, long userId, long parentResourcePrimaryKey);
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the matching registrations
 	 */
 	public java.util.List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId);
+		long groupId, long parentResourcePrimaryKey);
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public java.util.List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end);
+		long groupId, long parentResourcePrimaryKey, int start, int end);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end,
+		long groupId, long parentResourcePrimaryKey, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -757,101 +763,101 @@ public interface RegistrationPersistence extends BasePersistence<Registration> {
 	 * @return the ordered range of matching registrations
 	 */
 	public java.util.List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end,
+		long groupId, long parentResourcePrimaryKey, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator,
 		boolean retrieveFromCache);
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByChildArticleRegistrations_First(
-			long groupId, long parentArticleId,
+			long groupId, long parentResourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByChildArticleRegistrations_First(
-		long groupId, long parentArticleId,
+		long groupId, long parentResourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public Registration findByChildArticleRegistrations_Last(
-			long groupId, long parentArticleId,
+			long groupId, long parentResourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public Registration fetchByChildArticleRegistrations_Last(
-		long groupId, long parentArticleId,
+		long groupId, long parentResourcePrimaryKey,
 		com.liferay.portal.kernel.util.OrderByComparator<Registration>
 			orderByComparator);
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public Registration[] findByChildArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long parentArticleId,
+			long registrationId, long groupId, long parentResourcePrimaryKey,
 			com.liferay.portal.kernel.util.OrderByComparator<Registration>
 				orderByComparator)
 		throws NoSuchRegistrationException;
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and parentArticleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 */
 	public void removeByChildArticleRegistrations(
-		long groupId, long parentArticleId);
+		long groupId, long parentResourcePrimaryKey);
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the number of matching registrations
 	 */
 	public int countByChildArticleRegistrations(
-		long groupId, long parentArticleId);
+		long groupId, long parentResourcePrimaryKey);
 
 	/**
 	 * Caches the registration in the entity cache if it is enabled.

--- a/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/persistence/RegistrationUtil.java
+++ b/modules/registration-service/registration-service-api/src/main/java/nl/deltares/dsd/registration/service/persistence/RegistrationUtil.java
@@ -318,69 +318,70 @@ public class RegistrationUtil {
 	}
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the matching registrations
 	 */
 	public static List<Registration> findByArticleRegistrations(
-		long groupId, long articleId) {
+		long groupId, long resourcePrimaryKey) {
 
-		return getPersistence().findByArticleRegistrations(groupId, articleId);
+		return getPersistence().findByArticleRegistrations(
+			groupId, resourcePrimaryKey);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public static List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end) {
+		long groupId, long resourcePrimaryKey, int start, int end) {
 
 		return getPersistence().findByArticleRegistrations(
-			groupId, articleId, start, end);
+			groupId, resourcePrimaryKey, start, end);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end,
+		long groupId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().findByArticleRegistrations(
-			groupId, articleId, start, end, orderByComparator);
+			groupId, resourcePrimaryKey, start, end, orderByComparator);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -388,147 +389,149 @@ public class RegistrationUtil {
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end,
+		long groupId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
 		return getPersistence().findByArticleRegistrations(
-			groupId, articleId, start, end, orderByComparator,
+			groupId, resourcePrimaryKey, start, end, orderByComparator,
 			retrieveFromCache);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByArticleRegistrations_First(
-			long groupId, long articleId,
+			long groupId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByArticleRegistrations_First(
-			groupId, articleId, orderByComparator);
+			groupId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByArticleRegistrations_First(
-		long groupId, long articleId,
+		long groupId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByArticleRegistrations_First(
-			groupId, articleId, orderByComparator);
+			groupId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByArticleRegistrations_Last(
-			long groupId, long articleId,
+			long groupId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByArticleRegistrations_Last(
-			groupId, articleId, orderByComparator);
+			groupId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByArticleRegistrations_Last(
-		long groupId, long articleId,
+		long groupId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByArticleRegistrations_Last(
-			groupId, articleId, orderByComparator);
+			groupId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public static Registration[] findByArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long articleId,
+			long registrationId, long groupId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByArticleRegistrations_PrevAndNext(
-			registrationId, groupId, articleId, orderByComparator);
+			registrationId, groupId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and articleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and resourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 */
 	public static void removeByArticleRegistrations(
-		long groupId, long articleId) {
+		long groupId, long resourcePrimaryKey) {
 
-		getPersistence().removeByArticleRegistrations(groupId, articleId);
+		getPersistence().removeByArticleRegistrations(
+			groupId, resourcePrimaryKey);
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the number of matching registrations
 	 */
 	public static int countByArticleRegistrations(
-		long groupId, long articleId) {
+		long groupId, long resourcePrimaryKey) {
 
-		return getPersistence().countByArticleRegistrations(groupId, articleId);
+		return getPersistence().countByArticleRegistrations(
+			groupId, resourcePrimaryKey);
 	}
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the matching registrations
 	 */
 	public static List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourcePrimaryKey) {
 
 		return getPersistence().findByUserArticleRegistrations(
-			groupId, userId, articleId);
+			groupId, userId, resourcePrimaryKey);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -536,20 +539,21 @@ public class RegistrationUtil {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public static List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end) {
+		long groupId, long userId, long resourcePrimaryKey, int start,
+		int end) {
 
 		return getPersistence().findByUserArticleRegistrations(
-			groupId, userId, articleId, start, end);
+			groupId, userId, resourcePrimaryKey, start, end);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -557,22 +561,22 @@ public class RegistrationUtil {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end,
+		long groupId, long userId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().findByUserArticleRegistrations(
-			groupId, userId, articleId, start, end, orderByComparator);
+			groupId, userId, resourcePrimaryKey, start, end, orderByComparator);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -580,7 +584,7 @@ public class RegistrationUtil {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -588,156 +592,158 @@ public class RegistrationUtil {
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end,
+		long groupId, long userId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
 		return getPersistence().findByUserArticleRegistrations(
-			groupId, userId, articleId, start, end, orderByComparator,
+			groupId, userId, resourcePrimaryKey, start, end, orderByComparator,
 			retrieveFromCache);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByUserArticleRegistrations_First(
-			long groupId, long userId, long articleId,
+			long groupId, long userId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByUserArticleRegistrations_First(
-			groupId, userId, articleId, orderByComparator);
+			groupId, userId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByUserArticleRegistrations_First(
-		long groupId, long userId, long articleId,
+		long groupId, long userId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByUserArticleRegistrations_First(
-			groupId, userId, articleId, orderByComparator);
+			groupId, userId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByUserArticleRegistrations_Last(
-			long groupId, long userId, long articleId,
+			long groupId, long userId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByUserArticleRegistrations_Last(
-			groupId, userId, articleId, orderByComparator);
+			groupId, userId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByUserArticleRegistrations_Last(
-		long groupId, long userId, long articleId,
+		long groupId, long userId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByUserArticleRegistrations_Last(
-			groupId, userId, articleId, orderByComparator);
+			groupId, userId, resourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public static Registration[] findByUserArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long userId, long articleId,
+			long registrationId, long groupId, long userId,
+			long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByUserArticleRegistrations_PrevAndNext(
-			registrationId, groupId, userId, articleId, orderByComparator);
+			registrationId, groupId, userId, resourcePrimaryKey,
+			orderByComparator);
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 */
 	public static void removeByUserArticleRegistrations(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourcePrimaryKey) {
 
 		getPersistence().removeByUserArticleRegistrations(
-			groupId, userId, articleId);
+			groupId, userId, resourcePrimaryKey);
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the number of matching registrations
 	 */
 	public static int countByUserArticleRegistrations(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourcePrimaryKey) {
 
 		return getPersistence().countByUserArticleRegistrations(
-			groupId, userId, articleId);
+			groupId, userId, resourcePrimaryKey);
 	}
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the matching registrations
 	 */
 	public static List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId) {
+		long groupId, long userId, long parentResourcePrimaryKey) {
 
 		return getPersistence().findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId);
+			groupId, userId, parentResourcePrimaryKey);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -745,20 +751,21 @@ public class RegistrationUtil {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public static List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end) {
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end) {
 
 		return getPersistence().findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, start, end);
+			groupId, userId, parentResourcePrimaryKey, start, end);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -766,22 +773,23 @@ public class RegistrationUtil {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end,
-		OrderByComparator<Registration> orderByComparator) {
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end, OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, start, end, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, start, end,
+			orderByComparator);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -789,7 +797,7 @@ public class RegistrationUtil {
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -797,96 +805,96 @@ public class RegistrationUtil {
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end,
-		OrderByComparator<Registration> orderByComparator,
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end, OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
 		return getPersistence().findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, start, end, orderByComparator,
-			retrieveFromCache);
+			groupId, userId, parentResourcePrimaryKey, start, end,
+			orderByComparator, retrieveFromCache);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByUserChildArticleRegistrations_First(
-			long groupId, long userId, long parentArticleId,
+			long groupId, long userId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByUserChildArticleRegistrations_First(
-			groupId, userId, parentArticleId, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByUserChildArticleRegistrations_First(
-		long groupId, long userId, long parentArticleId,
+		long groupId, long userId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByUserChildArticleRegistrations_First(
-			groupId, userId, parentArticleId, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByUserChildArticleRegistrations_Last(
-			long groupId, long userId, long parentArticleId,
+			long groupId, long userId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByUserChildArticleRegistrations_Last(
-			groupId, userId, parentArticleId, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByUserChildArticleRegistrations_Last(
-		long groupId, long userId, long parentArticleId,
+		long groupId, long userId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByUserChildArticleRegistrations_Last(
-			groupId, userId, parentArticleId, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
@@ -894,110 +902,110 @@ public class RegistrationUtil {
 	public static Registration[]
 			findByUserChildArticleRegistrations_PrevAndNext(
 				long registrationId, long groupId, long userId,
-				long parentArticleId,
+				long parentResourcePrimaryKey,
 				OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByUserChildArticleRegistrations_PrevAndNext(
-			registrationId, groupId, userId, parentArticleId,
+			registrationId, groupId, userId, parentResourcePrimaryKey,
 			orderByComparator);
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 */
 	public static void removeByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId) {
+		long groupId, long userId, long parentResourcePrimaryKey) {
 
 		getPersistence().removeByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId);
+			groupId, userId, parentResourcePrimaryKey);
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the number of matching registrations
 	 */
 	public static int countByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId) {
+		long groupId, long userId, long parentResourcePrimaryKey) {
 
 		return getPersistence().countByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId);
+			groupId, userId, parentResourcePrimaryKey);
 	}
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the matching registrations
 	 */
 	public static List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId) {
+		long groupId, long parentResourcePrimaryKey) {
 
 		return getPersistence().findByChildArticleRegistrations(
-			groupId, parentArticleId);
+			groupId, parentResourcePrimaryKey);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	public static List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end) {
+		long groupId, long parentResourcePrimaryKey, int start, int end) {
 
 		return getPersistence().findByChildArticleRegistrations(
-			groupId, parentArticleId, start, end);
+			groupId, parentResourcePrimaryKey, start, end);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end,
+		long groupId, long parentResourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().findByChildArticleRegistrations(
-			groupId, parentArticleId, start, end, orderByComparator);
+			groupId, parentResourcePrimaryKey, start, end, orderByComparator);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1005,130 +1013,131 @@ public class RegistrationUtil {
 	 * @return the ordered range of matching registrations
 	 */
 	public static List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end,
+		long groupId, long parentResourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
 		return getPersistence().findByChildArticleRegistrations(
-			groupId, parentArticleId, start, end, orderByComparator,
+			groupId, parentResourcePrimaryKey, start, end, orderByComparator,
 			retrieveFromCache);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByChildArticleRegistrations_First(
-			long groupId, long parentArticleId,
+			long groupId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByChildArticleRegistrations_First(
-			groupId, parentArticleId, orderByComparator);
+			groupId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByChildArticleRegistrations_First(
-		long groupId, long parentArticleId,
+		long groupId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByChildArticleRegistrations_First(
-			groupId, parentArticleId, orderByComparator);
+			groupId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	public static Registration findByChildArticleRegistrations_Last(
-			long groupId, long parentArticleId,
+			long groupId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByChildArticleRegistrations_Last(
-			groupId, parentArticleId, orderByComparator);
+			groupId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	public static Registration fetchByChildArticleRegistrations_Last(
-		long groupId, long parentArticleId,
+		long groupId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return getPersistence().fetchByChildArticleRegistrations_Last(
-			groupId, parentArticleId, orderByComparator);
+			groupId, parentResourcePrimaryKey, orderByComparator);
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	public static Registration[] findByChildArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long parentArticleId,
+			long registrationId, long groupId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws nl.deltares.dsd.registration.exception.
 			NoSuchRegistrationException {
 
 		return getPersistence().findByChildArticleRegistrations_PrevAndNext(
-			registrationId, groupId, parentArticleId, orderByComparator);
+			registrationId, groupId, parentResourcePrimaryKey,
+			orderByComparator);
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and parentArticleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 */
 	public static void removeByChildArticleRegistrations(
-		long groupId, long parentArticleId) {
+		long groupId, long parentResourcePrimaryKey) {
 
 		getPersistence().removeByChildArticleRegistrations(
-			groupId, parentArticleId);
+			groupId, parentResourcePrimaryKey);
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the number of matching registrations
 	 */
 	public static int countByChildArticleRegistrations(
-		long groupId, long parentArticleId) {
+		long groupId, long parentResourcePrimaryKey) {
 
 		return getPersistence().countByChildArticleRegistrations(
-			groupId, parentArticleId);
+			groupId, parentResourcePrimaryKey);
 	}
 
 	/**

--- a/modules/registration-service/registration-service-service/service.xml
+++ b/modules/registration-service/registration-service-service/service.xml
@@ -18,13 +18,13 @@
 
 		<column name="companyId" type="long" />
 		<column name="userId" type="long" />
-		<column name="articleId" type="long" />
+		<column name="resourcePrimaryKey" type="long" />
 
 		<!-- Other fields -->
 		<column name="userPreferences" type="String" />
 		<column name="startTime" type="Date" />
 		<column name="endTime" type="Date" />
-		<column name="parentArticleId" type="long" />
+		<column name="parentResourcePrimaryKey" type="long" />
 
 		<!-- Order -->
 
@@ -41,24 +41,24 @@
 
 		<finder name="ArticleRegistrations" return-type="Collection">
 			<finder-column name="groupId" />
-			<finder-column name="articleId" />
+			<finder-column name="resourcePrimaryKey" />
 		</finder>
 
 		<finder name="UserArticleRegistrations" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="userId" />
-			<finder-column name="articleId" />
+			<finder-column name="resourcePrimaryKey" />
 		</finder>
 
 		<finder name="UserChildArticleRegistrations" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="userId" />
-			<finder-column name="parentArticleId" />
+			<finder-column name="parentResourcePrimaryKey" />
 		</finder>
 
 		<finder name="ChildArticleRegistrations" return-type="Collection">
 			<finder-column name="groupId" />
-			<finder-column name="parentArticleId" />
+			<finder-column name="parentResourcePrimaryKey" />
 		</finder>
 
 	</entity>

--- a/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/model/impl/RegistrationCacheModel.java
+++ b/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/model/impl/RegistrationCacheModel.java
@@ -76,16 +76,16 @@ public class RegistrationCacheModel
 		sb.append(companyId);
 		sb.append(", userId=");
 		sb.append(userId);
-		sb.append(", articleId=");
-		sb.append(articleId);
+		sb.append(", resourcePrimaryKey=");
+		sb.append(resourcePrimaryKey);
 		sb.append(", userPreferences=");
 		sb.append(userPreferences);
 		sb.append(", startTime=");
 		sb.append(startTime);
 		sb.append(", endTime=");
 		sb.append(endTime);
-		sb.append(", parentArticleId=");
-		sb.append(parentArticleId);
+		sb.append(", parentResourcePrimaryKey=");
+		sb.append(parentResourcePrimaryKey);
 		sb.append("}");
 
 		return sb.toString();
@@ -99,7 +99,7 @@ public class RegistrationCacheModel
 		registrationImpl.setGroupId(groupId);
 		registrationImpl.setCompanyId(companyId);
 		registrationImpl.setUserId(userId);
-		registrationImpl.setArticleId(articleId);
+		registrationImpl.setResourcePrimaryKey(resourcePrimaryKey);
 
 		if (userPreferences == null) {
 			registrationImpl.setUserPreferences("");
@@ -122,7 +122,7 @@ public class RegistrationCacheModel
 			registrationImpl.setEndTime(new Date(endTime));
 		}
 
-		registrationImpl.setParentArticleId(parentArticleId);
+		registrationImpl.setParentResourcePrimaryKey(parentResourcePrimaryKey);
 
 		registrationImpl.resetOriginalValues();
 
@@ -139,12 +139,12 @@ public class RegistrationCacheModel
 
 		userId = objectInput.readLong();
 
-		articleId = objectInput.readLong();
+		resourcePrimaryKey = objectInput.readLong();
 		userPreferences = objectInput.readUTF();
 		startTime = objectInput.readLong();
 		endTime = objectInput.readLong();
 
-		parentArticleId = objectInput.readLong();
+		parentResourcePrimaryKey = objectInput.readLong();
 	}
 
 	@Override
@@ -157,7 +157,7 @@ public class RegistrationCacheModel
 
 		objectOutput.writeLong(userId);
 
-		objectOutput.writeLong(articleId);
+		objectOutput.writeLong(resourcePrimaryKey);
 
 		if (userPreferences == null) {
 			objectOutput.writeUTF("");
@@ -169,17 +169,17 @@ public class RegistrationCacheModel
 		objectOutput.writeLong(startTime);
 		objectOutput.writeLong(endTime);
 
-		objectOutput.writeLong(parentArticleId);
+		objectOutput.writeLong(parentResourcePrimaryKey);
 	}
 
 	public long registrationId;
 	public long groupId;
 	public long companyId;
 	public long userId;
-	public long articleId;
+	public long resourcePrimaryKey;
 	public String userPreferences;
 	public long startTime;
 	public long endTime;
-	public long parentArticleId;
+	public long parentResourcePrimaryKey;
 
 }

--- a/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/model/impl/RegistrationModelImpl.java
+++ b/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/model/impl/RegistrationModelImpl.java
@@ -74,9 +74,9 @@ public class RegistrationModelImpl
 	public static final Object[][] TABLE_COLUMNS = {
 		{"registrationId", Types.BIGINT}, {"groupId", Types.BIGINT},
 		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"articleId", Types.BIGINT}, {"userPreferences", Types.VARCHAR},
-		{"startTime", Types.TIMESTAMP}, {"endTime", Types.TIMESTAMP},
-		{"parentArticleId", Types.BIGINT}
+		{"resourcePrimaryKey", Types.BIGINT},
+		{"userPreferences", Types.VARCHAR}, {"startTime", Types.TIMESTAMP},
+		{"endTime", Types.TIMESTAMP}, {"parentResourcePrimaryKey", Types.BIGINT}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -87,15 +87,15 @@ public class RegistrationModelImpl
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
-		TABLE_COLUMNS_MAP.put("articleId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("resourcePrimaryKey", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userPreferences", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("startTime", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("endTime", Types.TIMESTAMP);
-		TABLE_COLUMNS_MAP.put("parentArticleId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("parentResourcePrimaryKey", Types.BIGINT);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Registrations_Registration (registrationId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,articleId LONG,userPreferences STRING null,startTime DATE null,endTime DATE null,parentArticleId LONG)";
+		"create table Registrations_Registration (registrationId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,resourcePrimaryKey LONG,userPreferences STRING null,startTime DATE null,endTime DATE null,parentResourcePrimaryKey LONG)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table Registrations_Registration";
@@ -127,11 +127,11 @@ public class RegistrationModelImpl
 			"value.object.column.bitmask.enabled.nl.deltares.dsd.registration.model.Registration"),
 		true);
 
-	public static final long ARTICLEID_COLUMN_BITMASK = 1L;
+	public static final long GROUPID_COLUMN_BITMASK = 1L;
 
-	public static final long GROUPID_COLUMN_BITMASK = 2L;
+	public static final long PARENTRESOURCEPRIMARYKEY_COLUMN_BITMASK = 2L;
 
-	public static final long PARENTARTICLEID_COLUMN_BITMASK = 4L;
+	public static final long RESOURCEPRIMARYKEY_COLUMN_BITMASK = 4L;
 
 	public static final long USERID_COLUMN_BITMASK = 8L;
 
@@ -351,24 +351,25 @@ public class RegistrationModelImpl
 
 			});
 		attributeGetterFunctions.put(
-			"articleId",
+			"resourcePrimaryKey",
 			new Function<Registration, Object>() {
 
 				@Override
 				public Object apply(Registration registration) {
-					return registration.getArticleId();
+					return registration.getResourcePrimaryKey();
 				}
 
 			});
 		attributeSetterBiConsumers.put(
-			"articleId",
+			"resourcePrimaryKey",
 			new BiConsumer<Registration, Object>() {
 
 				@Override
 				public void accept(
-					Registration registration, Object articleId) {
+					Registration registration, Object resourcePrimaryKey) {
 
-					registration.setArticleId((Long)articleId);
+					registration.setResourcePrimaryKey(
+						(Long)resourcePrimaryKey);
 				}
 
 			});
@@ -437,24 +438,26 @@ public class RegistrationModelImpl
 
 			});
 		attributeGetterFunctions.put(
-			"parentArticleId",
+			"parentResourcePrimaryKey",
 			new Function<Registration, Object>() {
 
 				@Override
 				public Object apply(Registration registration) {
-					return registration.getParentArticleId();
+					return registration.getParentResourcePrimaryKey();
 				}
 
 			});
 		attributeSetterBiConsumers.put(
-			"parentArticleId",
+			"parentResourcePrimaryKey",
 			new BiConsumer<Registration, Object>() {
 
 				@Override
 				public void accept(
-					Registration registration, Object parentArticleId) {
+					Registration registration,
+					Object parentResourcePrimaryKey) {
 
-					registration.setParentArticleId((Long)parentArticleId);
+					registration.setParentResourcePrimaryKey(
+						(Long)parentResourcePrimaryKey);
 				}
 
 			});
@@ -546,25 +549,25 @@ public class RegistrationModelImpl
 	}
 
 	@Override
-	public long getArticleId() {
-		return _articleId;
+	public long getResourcePrimaryKey() {
+		return _resourcePrimaryKey;
 	}
 
 	@Override
-	public void setArticleId(long articleId) {
-		_columnBitmask |= ARTICLEID_COLUMN_BITMASK;
+	public void setResourcePrimaryKey(long resourcePrimaryKey) {
+		_columnBitmask |= RESOURCEPRIMARYKEY_COLUMN_BITMASK;
 
-		if (!_setOriginalArticleId) {
-			_setOriginalArticleId = true;
+		if (!_setOriginalResourcePrimaryKey) {
+			_setOriginalResourcePrimaryKey = true;
 
-			_originalArticleId = _articleId;
+			_originalResourcePrimaryKey = _resourcePrimaryKey;
 		}
 
-		_articleId = articleId;
+		_resourcePrimaryKey = resourcePrimaryKey;
 	}
 
-	public long getOriginalArticleId() {
-		return _originalArticleId;
+	public long getOriginalResourcePrimaryKey() {
+		return _originalResourcePrimaryKey;
 	}
 
 	@Override
@@ -605,25 +608,25 @@ public class RegistrationModelImpl
 	}
 
 	@Override
-	public long getParentArticleId() {
-		return _parentArticleId;
+	public long getParentResourcePrimaryKey() {
+		return _parentResourcePrimaryKey;
 	}
 
 	@Override
-	public void setParentArticleId(long parentArticleId) {
-		_columnBitmask |= PARENTARTICLEID_COLUMN_BITMASK;
+	public void setParentResourcePrimaryKey(long parentResourcePrimaryKey) {
+		_columnBitmask |= PARENTRESOURCEPRIMARYKEY_COLUMN_BITMASK;
 
-		if (!_setOriginalParentArticleId) {
-			_setOriginalParentArticleId = true;
+		if (!_setOriginalParentResourcePrimaryKey) {
+			_setOriginalParentResourcePrimaryKey = true;
 
-			_originalParentArticleId = _parentArticleId;
+			_originalParentResourcePrimaryKey = _parentResourcePrimaryKey;
 		}
 
-		_parentArticleId = parentArticleId;
+		_parentResourcePrimaryKey = parentResourcePrimaryKey;
 	}
 
-	public long getOriginalParentArticleId() {
-		return _originalParentArticleId;
+	public long getOriginalParentResourcePrimaryKey() {
+		return _originalParentResourcePrimaryKey;
 	}
 
 	public long getColumnBitmask() {
@@ -666,11 +669,12 @@ public class RegistrationModelImpl
 		registrationImpl.setGroupId(getGroupId());
 		registrationImpl.setCompanyId(getCompanyId());
 		registrationImpl.setUserId(getUserId());
-		registrationImpl.setArticleId(getArticleId());
+		registrationImpl.setResourcePrimaryKey(getResourcePrimaryKey());
 		registrationImpl.setUserPreferences(getUserPreferences());
 		registrationImpl.setStartTime(getStartTime());
 		registrationImpl.setEndTime(getEndTime());
-		registrationImpl.setParentArticleId(getParentArticleId());
+		registrationImpl.setParentResourcePrimaryKey(
+			getParentResourcePrimaryKey());
 
 		registrationImpl.resetOriginalValues();
 
@@ -741,15 +745,15 @@ public class RegistrationModelImpl
 
 		registrationModelImpl._setOriginalUserId = false;
 
-		registrationModelImpl._originalArticleId =
-			registrationModelImpl._articleId;
+		registrationModelImpl._originalResourcePrimaryKey =
+			registrationModelImpl._resourcePrimaryKey;
 
-		registrationModelImpl._setOriginalArticleId = false;
+		registrationModelImpl._setOriginalResourcePrimaryKey = false;
 
-		registrationModelImpl._originalParentArticleId =
-			registrationModelImpl._parentArticleId;
+		registrationModelImpl._originalParentResourcePrimaryKey =
+			registrationModelImpl._parentResourcePrimaryKey;
 
-		registrationModelImpl._setOriginalParentArticleId = false;
+		registrationModelImpl._setOriginalParentResourcePrimaryKey = false;
 
 		registrationModelImpl._columnBitmask = 0;
 	}
@@ -767,7 +771,7 @@ public class RegistrationModelImpl
 
 		registrationCacheModel.userId = getUserId();
 
-		registrationCacheModel.articleId = getArticleId();
+		registrationCacheModel.resourcePrimaryKey = getResourcePrimaryKey();
 
 		registrationCacheModel.userPreferences = getUserPreferences();
 
@@ -795,7 +799,8 @@ public class RegistrationModelImpl
 			registrationCacheModel.endTime = Long.MIN_VALUE;
 		}
 
-		registrationCacheModel.parentArticleId = getParentArticleId();
+		registrationCacheModel.parentResourcePrimaryKey =
+			getParentResourcePrimaryKey();
 
 		return registrationCacheModel;
 	}
@@ -878,15 +883,15 @@ public class RegistrationModelImpl
 	private long _userId;
 	private long _originalUserId;
 	private boolean _setOriginalUserId;
-	private long _articleId;
-	private long _originalArticleId;
-	private boolean _setOriginalArticleId;
+	private long _resourcePrimaryKey;
+	private long _originalResourcePrimaryKey;
+	private boolean _setOriginalResourcePrimaryKey;
 	private String _userPreferences;
 	private Date _startTime;
 	private Date _endTime;
-	private long _parentArticleId;
-	private long _originalParentArticleId;
-	private boolean _setOriginalParentArticleId;
+	private long _parentResourcePrimaryKey;
+	private long _originalParentResourcePrimaryKey;
+	private boolean _setOriginalParentResourcePrimaryKey;
 	private long _columnBitmask;
 	private Registration _escapedModel;
 

--- a/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/service/impl/RegistrationLocalServiceImpl.java
+++ b/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/service/impl/RegistrationLocalServiceImpl.java
@@ -45,7 +45,7 @@ public class RegistrationLocalServiceImpl
 	 *
 	 * Never reference this class directly. Use <code>nl.deltares.dsd.registration.service.RegistrationLocalService</code> via injection or a <code>org.osgi.util.tracker.ServiceTracker</code> or use <code>nl.deltares.dsd.registration.service.RegistrationLocalServiceUtil</code>.
 	 */
-	public void addUserRegistration(long companyId, long groupId, long articleId, long parentArticleId,
+	public void addUserRegistration(long companyId, long groupId, long resouceId, long parentResourceId,
 									long userId, Date startTime, Date endTime, String preferences) {
 
 		//do not validate here. validation has already taken place
@@ -53,8 +53,8 @@ public class RegistrationLocalServiceImpl
 		Registration registration = RegistrationLocalServiceUtil.createRegistration(CounterLocalServiceUtil.increment(Registration.class.getName()));
 		registration.setCompanyId(companyId);
 		registration.setGroupId(groupId);
-		registration.setArticleId(articleId);
-		registration.setParentArticleId(parentArticleId);
+		registration.setResourcePrimaryKey(resouceId);
+		registration.setParentResourcePrimaryKey(parentResourceId);
 		registration.setUserId(userId);
 		registration.setStartTime(startTime);
 		registration.setEndTime(endTime);
@@ -65,35 +65,35 @@ public class RegistrationLocalServiceImpl
 	}
 
 	/**
-	 * Delete all registrations related to 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete all registrations related to 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 */
-	public void deleteAllRegistrationsAndChildRegistrations(long groupId, long articleId){
+	public void deleteAllRegistrationsAndChildRegistrations(long groupId, long resourceId){
 
-		//Remove all registrations with a parentArticleId equal to articleId
-		RegistrationUtil.removeByChildArticleRegistrations(groupId, articleId);
+		//Remove all registrations with a parentArticleId equal to resourceId
+		RegistrationUtil.removeByChildArticleRegistrations(groupId, resourceId);
 
-		//Remove all registrations for articleId
-		RegistrationUtil.removeByArticleRegistrations(groupId, articleId);
+		//Remove all registrations for resourceId
+		RegistrationUtil.removeByArticleRegistrations(groupId, resourceId);
 
 	}
 
 	/**
-	 * Delete user registrations for 'articleId'. This inlcudes all registration with a parentArticleId
-	 * that matches 'articleId'.
+	 * Delete user registrations for 'resourceId'. This inlcudes all registration with a parentArticleId
+	 * that matches 'resourceId'.
 	 * @param groupId Site Identifier
-	 * @param articleId Article Identifier being removed.
+	 * @param resourceId Article Identifier being removed.
 	 * @param userId User for which to remove registration
 	 */
-	public void deleteUserRegistrationAndChildRegistrations(long groupId, long articleId, long userId){
+	public void deleteUserRegistrationAndChildRegistrations(long groupId, long resourceId, long userId){
 
-		//Remove all registrations with a parentArticleId equal to articleId
-		RegistrationUtil.removeByUserChildArticleRegistrations(groupId, userId, articleId);
+		//Remove all registrations with a parentArticleId equal to resourceId
+		RegistrationUtil.removeByUserChildArticleRegistrations(groupId, userId, resourceId);
 
-		//Remove all registrations for articleId
-		RegistrationUtil.removeByUserArticleRegistrations(groupId, userId, articleId);
+		//Remove all registrations for resourceId
+		RegistrationUtil.removeByUserArticleRegistrations(groupId, userId, resourceId);
 
 	}
 
@@ -109,19 +109,19 @@ public class RegistrationLocalServiceImpl
 		List<Registration> overlappingRegistrations = RegistrationUtil.findWithDynamicQuery(query);
 		if (overlappingRegistrations.size() == 0) return new long[0];
 
-		long[] articleIds = new long[overlappingRegistrations.size()];
+		long[] resourceIds = new long[overlappingRegistrations.size()];
 		int i = 0;
 		for (Registration overlappingRegistration : overlappingRegistrations) {
-			articleIds[i++] = overlappingRegistration.getArticleId();
+			resourceIds[i++] = overlappingRegistration.getResourcePrimaryKey();
 		}
-		return articleIds;
+		return resourceIds;
 	}
 
-	public int getRegistrationsCount(long groupId, long articleId){
-		return RegistrationUtil.countByArticleRegistrations(groupId, articleId);
+	public int getRegistrationsCount(long groupId, long resourceId){
+		return RegistrationUtil.countByArticleRegistrations(groupId, resourceId);
 	}
 
-	public int getRegistrationsCount(long groupId, long userId, long articleId)  {
-		return  RegistrationUtil.countByUserArticleRegistrations(groupId, userId, articleId);
+	public int getRegistrationsCount(long groupId, long userId, long resourceId)  {
+		return  RegistrationUtil.countByUserArticleRegistrations(groupId, userId, resourceId);
 	}
 }

--- a/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/service/persistence/impl/RegistrationPersistenceImpl.java
+++ b/modules/registration-service/registration-service-service/src/main/java/nl/deltares/dsd/registration/service/persistence/impl/RegistrationPersistenceImpl.java
@@ -639,49 +639,51 @@ public class RegistrationPersistenceImpl
 	private FinderPath _finderPathCountByArticleRegistrations;
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the matching registrations
 	 */
 	@Override
 	public List<Registration> findByArticleRegistrations(
-		long groupId, long articleId) {
+		long groupId, long resourcePrimaryKey) {
 
 		return findByArticleRegistrations(
-			groupId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+			groupId, resourcePrimaryKey, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	@Override
 	public List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end) {
+		long groupId, long resourcePrimaryKey, int start, int end) {
 
-		return findByArticleRegistrations(groupId, articleId, start, end, null);
+		return findByArticleRegistrations(
+			groupId, resourcePrimaryKey, start, end, null);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -689,22 +691,22 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end,
+		long groupId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return findByArticleRegistrations(
-			groupId, articleId, start, end, orderByComparator, true);
+			groupId, resourcePrimaryKey, start, end, orderByComparator, true);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -713,7 +715,7 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByArticleRegistrations(
-		long groupId, long articleId, int start, int end,
+		long groupId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
@@ -726,12 +728,12 @@ public class RegistrationPersistenceImpl
 
 			pagination = false;
 			finderPath = _finderPathWithoutPaginationFindByArticleRegistrations;
-			finderArgs = new Object[] {groupId, articleId};
+			finderArgs = new Object[] {groupId, resourcePrimaryKey};
 		}
 		else {
 			finderPath = _finderPathWithPaginationFindByArticleRegistrations;
 			finderArgs = new Object[] {
-				groupId, articleId, start, end, orderByComparator
+				groupId, resourcePrimaryKey, start, end, orderByComparator
 			};
 		}
 
@@ -744,7 +746,8 @@ public class RegistrationPersistenceImpl
 			if ((list != null) && !list.isEmpty()) {
 				for (Registration registration : list) {
 					if ((groupId != registration.getGroupId()) ||
-						(articleId != registration.getArticleId())) {
+						(resourcePrimaryKey !=
+							registration.getResourcePrimaryKey())) {
 
 						list = null;
 
@@ -769,7 +772,8 @@ public class RegistrationPersistenceImpl
 
 			query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_GROUPID_2);
 
-			query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_ARTICLEID_2);
+			query.append(
+				_FINDER_COLUMN_ARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -792,7 +796,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(groupId);
 
-				qPos.add(articleId);
+				qPos.add(resourcePrimaryKey);
 
 				if (!pagination) {
 					list = (List<Registration>)QueryUtil.list(
@@ -825,22 +829,22 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByArticleRegistrations_First(
-			long groupId, long articleId,
+			long groupId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByArticleRegistrations_First(
-			groupId, articleId, orderByComparator);
+			groupId, resourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -853,8 +857,8 @@ public class RegistrationPersistenceImpl
 		msg.append("groupId=");
 		msg.append(groupId);
 
-		msg.append(", articleId=");
-		msg.append(articleId);
+		msg.append(", resourcePrimaryKey=");
+		msg.append(resourcePrimaryKey);
 
 		msg.append("}");
 
@@ -862,20 +866,20 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByArticleRegistrations_First(
-		long groupId, long articleId,
+		long groupId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		List<Registration> list = findByArticleRegistrations(
-			groupId, articleId, 0, 1, orderByComparator);
+			groupId, resourcePrimaryKey, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -885,22 +889,22 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByArticleRegistrations_Last(
-			long groupId, long articleId,
+			long groupId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByArticleRegistrations_Last(
-			groupId, articleId, orderByComparator);
+			groupId, resourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -913,8 +917,8 @@ public class RegistrationPersistenceImpl
 		msg.append("groupId=");
 		msg.append(groupId);
 
-		msg.append(", articleId=");
-		msg.append(articleId);
+		msg.append(", resourcePrimaryKey=");
+		msg.append(resourcePrimaryKey);
 
 		msg.append("}");
 
@@ -922,26 +926,26 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByArticleRegistrations_Last(
-		long groupId, long articleId,
+		long groupId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
-		int count = countByArticleRegistrations(groupId, articleId);
+		int count = countByArticleRegistrations(groupId, resourcePrimaryKey);
 
 		if (count == 0) {
 			return null;
 		}
 
 		List<Registration> list = findByArticleRegistrations(
-			groupId, articleId, count - 1, count, orderByComparator);
+			groupId, resourcePrimaryKey, count - 1, count, orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -951,18 +955,18 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and articleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	@Override
 	public Registration[] findByArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long articleId,
+			long registrationId, long groupId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
@@ -976,14 +980,14 @@ public class RegistrationPersistenceImpl
 			Registration[] array = new RegistrationImpl[3];
 
 			array[0] = getByArticleRegistrations_PrevAndNext(
-				session, registration, groupId, articleId, orderByComparator,
-				true);
+				session, registration, groupId, resourcePrimaryKey,
+				orderByComparator, true);
 
 			array[1] = registration;
 
 			array[2] = getByArticleRegistrations_PrevAndNext(
-				session, registration, groupId, articleId, orderByComparator,
-				false);
+				session, registration, groupId, resourcePrimaryKey,
+				orderByComparator, false);
 
 			return array;
 		}
@@ -997,8 +1001,8 @@ public class RegistrationPersistenceImpl
 
 	protected Registration getByArticleRegistrations_PrevAndNext(
 		Session session, Registration registration, long groupId,
-		long articleId, OrderByComparator<Registration> orderByComparator,
-		boolean previous) {
+		long resourcePrimaryKey,
+		OrderByComparator<Registration> orderByComparator, boolean previous) {
 
 		StringBundler query = null;
 
@@ -1015,7 +1019,7 @@ public class RegistrationPersistenceImpl
 
 		query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_GROUPID_2);
 
-		query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_ARTICLEID_2);
+		query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -1088,7 +1092,7 @@ public class RegistrationPersistenceImpl
 
 		qPos.add(groupId);
 
-		qPos.add(articleId);
+		qPos.add(resourcePrimaryKey);
 
 		if (orderByComparator != null) {
 			for (Object orderByConditionValue :
@@ -1109,34 +1113,38 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and articleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and resourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 */
 	@Override
-	public void removeByArticleRegistrations(long groupId, long articleId) {
+	public void removeByArticleRegistrations(
+		long groupId, long resourcePrimaryKey) {
+
 		for (Registration registration :
 				findByArticleRegistrations(
-					groupId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-					null)) {
+					groupId, resourcePrimaryKey, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
 
 			remove(registration);
 		}
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and articleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the number of matching registrations
 	 */
 	@Override
-	public int countByArticleRegistrations(long groupId, long articleId) {
+	public int countByArticleRegistrations(
+		long groupId, long resourcePrimaryKey) {
+
 		FinderPath finderPath = _finderPathCountByArticleRegistrations;
 
-		Object[] finderArgs = new Object[] {groupId, articleId};
+		Object[] finderArgs = new Object[] {groupId, resourcePrimaryKey};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -1147,7 +1155,8 @@ public class RegistrationPersistenceImpl
 
 			query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_GROUPID_2);
 
-			query.append(_FINDER_COLUMN_ARTICLEREGISTRATIONS_ARTICLEID_2);
+			query.append(
+				_FINDER_COLUMN_ARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2);
 
 			String sql = query.toString();
 
@@ -1162,7 +1171,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(groupId);
 
-				qPos.add(articleId);
+				qPos.add(resourcePrimaryKey);
 
 				count = (Long)q.uniqueResult();
 
@@ -1185,8 +1194,8 @@ public class RegistrationPersistenceImpl
 		"registration.groupId = ? AND ";
 
 	private static final String
-		_FINDER_COLUMN_ARTICLEREGISTRATIONS_ARTICLEID_2 =
-			"registration.articleId = ?";
+		_FINDER_COLUMN_ARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2 =
+			"registration.resourcePrimaryKey = ?";
 
 	private FinderPath _finderPathWithPaginationFindByUserArticleRegistrations;
 	private FinderPath
@@ -1194,24 +1203,24 @@ public class RegistrationPersistenceImpl
 	private FinderPath _finderPathCountByUserArticleRegistrations;
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the matching registrations
 	 */
 	@Override
 	public List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourcePrimaryKey) {
 
 		return findByUserArticleRegistrations(
-			groupId, userId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			null);
+			groupId, userId, resourcePrimaryKey, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -1219,21 +1228,22 @@ public class RegistrationPersistenceImpl
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	@Override
 	public List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end) {
+		long groupId, long userId, long resourcePrimaryKey, int start,
+		int end) {
 
 		return findByUserArticleRegistrations(
-			groupId, userId, articleId, start, end, null);
+			groupId, userId, resourcePrimaryKey, start, end, null);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -1241,7 +1251,7 @@ public class RegistrationPersistenceImpl
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1249,15 +1259,16 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end,
+		long groupId, long userId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return findByUserArticleRegistrations(
-			groupId, userId, articleId, start, end, orderByComparator, true);
+			groupId, userId, resourcePrimaryKey, start, end, orderByComparator,
+			true);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -1265,7 +1276,7 @@ public class RegistrationPersistenceImpl
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1274,7 +1285,7 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByUserArticleRegistrations(
-		long groupId, long userId, long articleId, int start, int end,
+		long groupId, long userId, long resourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
@@ -1288,13 +1299,14 @@ public class RegistrationPersistenceImpl
 			pagination = false;
 			finderPath =
 				_finderPathWithoutPaginationFindByUserArticleRegistrations;
-			finderArgs = new Object[] {groupId, userId, articleId};
+			finderArgs = new Object[] {groupId, userId, resourcePrimaryKey};
 		}
 		else {
 			finderPath =
 				_finderPathWithPaginationFindByUserArticleRegistrations;
 			finderArgs = new Object[] {
-				groupId, userId, articleId, start, end, orderByComparator
+				groupId, userId, resourcePrimaryKey, start, end,
+				orderByComparator
 			};
 		}
 
@@ -1308,7 +1320,8 @@ public class RegistrationPersistenceImpl
 				for (Registration registration : list) {
 					if ((groupId != registration.getGroupId()) ||
 						(userId != registration.getUserId()) ||
-						(articleId != registration.getArticleId())) {
+						(resourcePrimaryKey !=
+							registration.getResourcePrimaryKey())) {
 
 						list = null;
 
@@ -1335,7 +1348,8 @@ public class RegistrationPersistenceImpl
 
 			query.append(_FINDER_COLUMN_USERARTICLEREGISTRATIONS_USERID_2);
 
-			query.append(_FINDER_COLUMN_USERARTICLEREGISTRATIONS_ARTICLEID_2);
+			query.append(
+				_FINDER_COLUMN_USERARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -1360,7 +1374,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(userId);
 
-				qPos.add(articleId);
+				qPos.add(resourcePrimaryKey);
 
 				if (!pagination) {
 					list = (List<Registration>)QueryUtil.list(
@@ -1393,23 +1407,23 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByUserArticleRegistrations_First(
-			long groupId, long userId, long articleId,
+			long groupId, long userId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByUserArticleRegistrations_First(
-			groupId, userId, articleId, orderByComparator);
+			groupId, userId, resourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -1425,8 +1439,8 @@ public class RegistrationPersistenceImpl
 		msg.append(", userId=");
 		msg.append(userId);
 
-		msg.append(", articleId=");
-		msg.append(articleId);
+		msg.append(", resourcePrimaryKey=");
+		msg.append(resourcePrimaryKey);
 
 		msg.append("}");
 
@@ -1434,21 +1448,21 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByUserArticleRegistrations_First(
-		long groupId, long userId, long articleId,
+		long groupId, long userId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		List<Registration> list = findByUserArticleRegistrations(
-			groupId, userId, articleId, 0, 1, orderByComparator);
+			groupId, userId, resourcePrimaryKey, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -1458,23 +1472,23 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByUserArticleRegistrations_Last(
-			long groupId, long userId, long articleId,
+			long groupId, long userId, long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByUserArticleRegistrations_Last(
-			groupId, userId, articleId, orderByComparator);
+			groupId, userId, resourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -1490,8 +1504,8 @@ public class RegistrationPersistenceImpl
 		msg.append(", userId=");
 		msg.append(userId);
 
-		msg.append(", articleId=");
-		msg.append(articleId);
+		msg.append(", resourcePrimaryKey=");
+		msg.append(resourcePrimaryKey);
 
 		msg.append("}");
 
@@ -1499,27 +1513,29 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByUserArticleRegistrations_Last(
-		long groupId, long userId, long articleId,
+		long groupId, long userId, long resourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
-		int count = countByUserArticleRegistrations(groupId, userId, articleId);
+		int count = countByUserArticleRegistrations(
+			groupId, userId, resourcePrimaryKey);
 
 		if (count == 0) {
 			return null;
 		}
 
 		List<Registration> list = findByUserArticleRegistrations(
-			groupId, userId, articleId, count - 1, count, orderByComparator);
+			groupId, userId, resourcePrimaryKey, count - 1, count,
+			orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -1529,19 +1545,20 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	@Override
 	public Registration[] findByUserArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long userId, long articleId,
+			long registrationId, long groupId, long userId,
+			long resourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
@@ -1555,13 +1572,13 @@ public class RegistrationPersistenceImpl
 			Registration[] array = new RegistrationImpl[3];
 
 			array[0] = getByUserArticleRegistrations_PrevAndNext(
-				session, registration, groupId, userId, articleId,
+				session, registration, groupId, userId, resourcePrimaryKey,
 				orderByComparator, true);
 
 			array[1] = registration;
 
 			array[2] = getByUserArticleRegistrations_PrevAndNext(
-				session, registration, groupId, userId, articleId,
+				session, registration, groupId, userId, resourcePrimaryKey,
 				orderByComparator, false);
 
 			return array;
@@ -1576,8 +1593,8 @@ public class RegistrationPersistenceImpl
 
 	protected Registration getByUserArticleRegistrations_PrevAndNext(
 		Session session, Registration registration, long groupId, long userId,
-		long articleId, OrderByComparator<Registration> orderByComparator,
-		boolean previous) {
+		long resourcePrimaryKey,
+		OrderByComparator<Registration> orderByComparator, boolean previous) {
 
 		StringBundler query = null;
 
@@ -1596,7 +1613,8 @@ public class RegistrationPersistenceImpl
 
 		query.append(_FINDER_COLUMN_USERARTICLEREGISTRATIONS_USERID_2);
 
-		query.append(_FINDER_COLUMN_USERARTICLEREGISTRATIONS_ARTICLEID_2);
+		query.append(
+			_FINDER_COLUMN_USERARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -1671,7 +1689,7 @@ public class RegistrationPersistenceImpl
 
 		qPos.add(userId);
 
-		qPos.add(articleId);
+		qPos.add(resourcePrimaryKey);
 
 		if (orderByComparator != null) {
 			for (Object orderByConditionValue :
@@ -1692,19 +1710,19 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and userId = &#63; and articleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 */
 	@Override
 	public void removeByUserArticleRegistrations(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourcePrimaryKey) {
 
 		for (Registration registration :
 				findByUserArticleRegistrations(
-					groupId, userId, articleId, QueryUtil.ALL_POS,
+					groupId, userId, resourcePrimaryKey, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
 			remove(registration);
@@ -1712,20 +1730,22 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and articleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and resourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param articleId the article ID
+	 * @param resourcePrimaryKey the resource primary key
 	 * @return the number of matching registrations
 	 */
 	@Override
 	public int countByUserArticleRegistrations(
-		long groupId, long userId, long articleId) {
+		long groupId, long userId, long resourcePrimaryKey) {
 
 		FinderPath finderPath = _finderPathCountByUserArticleRegistrations;
 
-		Object[] finderArgs = new Object[] {groupId, userId, articleId};
+		Object[] finderArgs = new Object[] {
+			groupId, userId, resourcePrimaryKey
+		};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -1738,7 +1758,8 @@ public class RegistrationPersistenceImpl
 
 			query.append(_FINDER_COLUMN_USERARTICLEREGISTRATIONS_USERID_2);
 
-			query.append(_FINDER_COLUMN_USERARTICLEREGISTRATIONS_ARTICLEID_2);
+			query.append(
+				_FINDER_COLUMN_USERARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2);
 
 			String sql = query.toString();
 
@@ -1755,7 +1776,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(userId);
 
-				qPos.add(articleId);
+				qPos.add(resourcePrimaryKey);
 
 				count = (Long)q.uniqueResult();
 
@@ -1783,8 +1804,8 @@ public class RegistrationPersistenceImpl
 			"registration.userId = ? AND ";
 
 	private static final String
-		_FINDER_COLUMN_USERARTICLEREGISTRATIONS_ARTICLEID_2 =
-			"registration.articleId = ?";
+		_FINDER_COLUMN_USERARTICLEREGISTRATIONS_RESOURCEPRIMARYKEY_2 =
+			"registration.resourcePrimaryKey = ?";
 
 	private FinderPath
 		_finderPathWithPaginationFindByUserChildArticleRegistrations;
@@ -1793,24 +1814,24 @@ public class RegistrationPersistenceImpl
 	private FinderPath _finderPathCountByUserChildArticleRegistrations;
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the matching registrations
 	 */
 	@Override
 	public List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId) {
+		long groupId, long userId, long parentResourcePrimaryKey) {
 
 		return findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, QueryUtil.ALL_POS,
+			groupId, userId, parentResourcePrimaryKey, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -1818,21 +1839,22 @@ public class RegistrationPersistenceImpl
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	@Override
 	public List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end) {
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end) {
 
 		return findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, start, end, null);
+			groupId, userId, parentResourcePrimaryKey, start, end, null);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -1840,7 +1862,7 @@ public class RegistrationPersistenceImpl
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1848,16 +1870,16 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end,
-		OrderByComparator<Registration> orderByComparator) {
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end, OrderByComparator<Registration> orderByComparator) {
 
 		return findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, start, end, orderByComparator,
-			true);
+			groupId, userId, parentResourcePrimaryKey, start, end,
+			orderByComparator, true);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
@@ -1865,7 +1887,7 @@ public class RegistrationPersistenceImpl
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1874,8 +1896,8 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId, int start, int end,
-		OrderByComparator<Registration> orderByComparator,
+		long groupId, long userId, long parentResourcePrimaryKey, int start,
+		int end, OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
 		boolean pagination = true;
@@ -1888,13 +1910,16 @@ public class RegistrationPersistenceImpl
 			pagination = false;
 			finderPath =
 				_finderPathWithoutPaginationFindByUserChildArticleRegistrations;
-			finderArgs = new Object[] {groupId, userId, parentArticleId};
+			finderArgs = new Object[] {
+				groupId, userId, parentResourcePrimaryKey
+			};
 		}
 		else {
 			finderPath =
 				_finderPathWithPaginationFindByUserChildArticleRegistrations;
 			finderArgs = new Object[] {
-				groupId, userId, parentArticleId, start, end, orderByComparator
+				groupId, userId, parentResourcePrimaryKey, start, end,
+				orderByComparator
 			};
 		}
 
@@ -1908,8 +1933,8 @@ public class RegistrationPersistenceImpl
 				for (Registration registration : list) {
 					if ((groupId != registration.getGroupId()) ||
 						(userId != registration.getUserId()) ||
-						(parentArticleId !=
-							registration.getParentArticleId())) {
+						(parentResourcePrimaryKey !=
+							registration.getParentResourcePrimaryKey())) {
 
 						list = null;
 
@@ -1938,7 +1963,7 @@ public class RegistrationPersistenceImpl
 			query.append(_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_USERID_2);
 
 			query.append(
-				_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2);
+				_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -1963,7 +1988,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(userId);
 
-				qPos.add(parentArticleId);
+				qPos.add(parentResourcePrimaryKey);
 
 				if (!pagination) {
 					list = (List<Registration>)QueryUtil.list(
@@ -1996,23 +2021,23 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByUserChildArticleRegistrations_First(
-			long groupId, long userId, long parentArticleId,
+			long groupId, long userId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByUserChildArticleRegistrations_First(
-			groupId, userId, parentArticleId, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -2028,8 +2053,8 @@ public class RegistrationPersistenceImpl
 		msg.append(", userId=");
 		msg.append(userId);
 
-		msg.append(", parentArticleId=");
-		msg.append(parentArticleId);
+		msg.append(", parentResourcePrimaryKey=");
+		msg.append(parentResourcePrimaryKey);
 
 		msg.append("}");
 
@@ -2037,21 +2062,21 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByUserChildArticleRegistrations_First(
-		long groupId, long userId, long parentArticleId,
+		long groupId, long userId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		List<Registration> list = findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, 0, 1, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -2061,23 +2086,23 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByUserChildArticleRegistrations_Last(
-			long groupId, long userId, long parentArticleId,
+			long groupId, long userId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByUserChildArticleRegistrations_Last(
-			groupId, userId, parentArticleId, orderByComparator);
+			groupId, userId, parentResourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -2093,8 +2118,8 @@ public class RegistrationPersistenceImpl
 		msg.append(", userId=");
 		msg.append(userId);
 
-		msg.append(", parentArticleId=");
-		msg.append(parentArticleId);
+		msg.append(", parentResourcePrimaryKey=");
+		msg.append(parentResourcePrimaryKey);
 
 		msg.append("}");
 
@@ -2102,28 +2127,28 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByUserChildArticleRegistrations_Last(
-		long groupId, long userId, long parentArticleId,
+		long groupId, long userId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		int count = countByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId);
+			groupId, userId, parentResourcePrimaryKey);
 
 		if (count == 0) {
 			return null;
 		}
 
 		List<Registration> list = findByUserChildArticleRegistrations(
-			groupId, userId, parentArticleId, count - 1, count,
+			groupId, userId, parentResourcePrimaryKey, count - 1, count,
 			orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -2134,12 +2159,12 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
@@ -2147,7 +2172,7 @@ public class RegistrationPersistenceImpl
 	@Override
 	public Registration[] findByUserChildArticleRegistrations_PrevAndNext(
 			long registrationId, long groupId, long userId,
-			long parentArticleId,
+			long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
@@ -2161,14 +2186,14 @@ public class RegistrationPersistenceImpl
 			Registration[] array = new RegistrationImpl[3];
 
 			array[0] = getByUserChildArticleRegistrations_PrevAndNext(
-				session, registration, groupId, userId, parentArticleId,
-				orderByComparator, true);
+				session, registration, groupId, userId,
+				parentResourcePrimaryKey, orderByComparator, true);
 
 			array[1] = registration;
 
 			array[2] = getByUserChildArticleRegistrations_PrevAndNext(
-				session, registration, groupId, userId, parentArticleId,
-				orderByComparator, false);
+				session, registration, groupId, userId,
+				parentResourcePrimaryKey, orderByComparator, false);
 
 			return array;
 		}
@@ -2182,8 +2207,8 @@ public class RegistrationPersistenceImpl
 
 	protected Registration getByUserChildArticleRegistrations_PrevAndNext(
 		Session session, Registration registration, long groupId, long userId,
-		long parentArticleId, OrderByComparator<Registration> orderByComparator,
-		boolean previous) {
+		long parentResourcePrimaryKey,
+		OrderByComparator<Registration> orderByComparator, boolean previous) {
 
 		StringBundler query = null;
 
@@ -2203,7 +2228,7 @@ public class RegistrationPersistenceImpl
 		query.append(_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_USERID_2);
 
 		query.append(
-			_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2);
+			_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -2278,7 +2303,7 @@ public class RegistrationPersistenceImpl
 
 		qPos.add(userId);
 
-		qPos.add(parentArticleId);
+		qPos.add(parentResourcePrimaryKey);
 
 		if (orderByComparator != null) {
 			for (Object orderByConditionValue :
@@ -2299,40 +2324,42 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 */
 	@Override
 	public void removeByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId) {
+		long groupId, long userId, long parentResourcePrimaryKey) {
 
 		for (Registration registration :
 				findByUserChildArticleRegistrations(
-					groupId, userId, parentArticleId, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null)) {
+					groupId, userId, parentResourcePrimaryKey,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
 			remove(registration);
 		}
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and parentArticleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and userId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param userId the user ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the number of matching registrations
 	 */
 	@Override
 	public int countByUserChildArticleRegistrations(
-		long groupId, long userId, long parentArticleId) {
+		long groupId, long userId, long parentResourcePrimaryKey) {
 
 		FinderPath finderPath = _finderPathCountByUserChildArticleRegistrations;
 
-		Object[] finderArgs = new Object[] {groupId, userId, parentArticleId};
+		Object[] finderArgs = new Object[] {
+			groupId, userId, parentResourcePrimaryKey
+		};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2347,7 +2374,7 @@ public class RegistrationPersistenceImpl
 			query.append(_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_USERID_2);
 
 			query.append(
-				_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2);
+				_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2);
 
 			String sql = query.toString();
 
@@ -2364,7 +2391,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(userId);
 
-				qPos.add(parentArticleId);
+				qPos.add(parentResourcePrimaryKey);
 
 				count = (Long)q.uniqueResult();
 
@@ -2392,8 +2419,8 @@ public class RegistrationPersistenceImpl
 			"registration.userId = ? AND ";
 
 	private static final String
-		_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2 =
-			"registration.parentArticleId = ?";
+		_FINDER_COLUMN_USERCHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2 =
+			"registration.parentResourcePrimaryKey = ?";
 
 	private FinderPath _finderPathWithPaginationFindByChildArticleRegistrations;
 	private FinderPath
@@ -2401,51 +2428,51 @@ public class RegistrationPersistenceImpl
 	private FinderPath _finderPathCountByChildArticleRegistrations;
 
 	/**
-	 * Returns all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the matching registrations
 	 */
 	@Override
 	public List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId) {
+		long groupId, long parentResourcePrimaryKey) {
 
 		return findByChildArticleRegistrations(
-			groupId, parentArticleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			null);
+			groupId, parentResourcePrimaryKey, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns a range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns a range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @return the range of matching registrations
 	 */
 	@Override
 	public List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end) {
+		long groupId, long parentResourcePrimaryKey, int start, int end) {
 
 		return findByChildArticleRegistrations(
-			groupId, parentArticleId, start, end, null);
+			groupId, parentResourcePrimaryKey, start, end, null);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -2453,22 +2480,23 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end,
+		long groupId, long parentResourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator) {
 
 		return findByChildArticleRegistrations(
-			groupId, parentArticleId, start, end, orderByComparator, true);
+			groupId, parentResourcePrimaryKey, start, end, orderByComparator,
+			true);
 	}
 
 	/**
-	 * Returns an ordered range of all the registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns an ordered range of all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>RegistrationModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param start the lower bound of the range of registrations
 	 * @param end the upper bound of the range of registrations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -2477,7 +2505,7 @@ public class RegistrationPersistenceImpl
 	 */
 	@Override
 	public List<Registration> findByChildArticleRegistrations(
-		long groupId, long parentArticleId, int start, int end,
+		long groupId, long parentResourcePrimaryKey, int start, int end,
 		OrderByComparator<Registration> orderByComparator,
 		boolean retrieveFromCache) {
 
@@ -2491,13 +2519,13 @@ public class RegistrationPersistenceImpl
 			pagination = false;
 			finderPath =
 				_finderPathWithoutPaginationFindByChildArticleRegistrations;
-			finderArgs = new Object[] {groupId, parentArticleId};
+			finderArgs = new Object[] {groupId, parentResourcePrimaryKey};
 		}
 		else {
 			finderPath =
 				_finderPathWithPaginationFindByChildArticleRegistrations;
 			finderArgs = new Object[] {
-				groupId, parentArticleId, start, end, orderByComparator
+				groupId, parentResourcePrimaryKey, start, end, orderByComparator
 			};
 		}
 
@@ -2510,8 +2538,8 @@ public class RegistrationPersistenceImpl
 			if ((list != null) && !list.isEmpty()) {
 				for (Registration registration : list) {
 					if ((groupId != registration.getGroupId()) ||
-						(parentArticleId !=
-							registration.getParentArticleId())) {
+						(parentResourcePrimaryKey !=
+							registration.getParentResourcePrimaryKey())) {
 
 						list = null;
 
@@ -2537,7 +2565,7 @@ public class RegistrationPersistenceImpl
 			query.append(_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_GROUPID_2);
 
 			query.append(
-				_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2);
+				_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -2560,7 +2588,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(groupId);
 
-				qPos.add(parentArticleId);
+				qPos.add(parentResourcePrimaryKey);
 
 				if (!pagination) {
 					list = (List<Registration>)QueryUtil.list(
@@ -2593,22 +2621,22 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByChildArticleRegistrations_First(
-			long groupId, long parentArticleId,
+			long groupId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByChildArticleRegistrations_First(
-			groupId, parentArticleId, orderByComparator);
+			groupId, parentResourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -2621,8 +2649,8 @@ public class RegistrationPersistenceImpl
 		msg.append("groupId=");
 		msg.append(groupId);
 
-		msg.append(", parentArticleId=");
-		msg.append(parentArticleId);
+		msg.append(", parentResourcePrimaryKey=");
+		msg.append(parentResourcePrimaryKey);
 
 		msg.append("}");
 
@@ -2630,20 +2658,20 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the first registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the first registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByChildArticleRegistrations_First(
-		long groupId, long parentArticleId,
+		long groupId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
 		List<Registration> list = findByChildArticleRegistrations(
-			groupId, parentArticleId, 0, 1, orderByComparator);
+			groupId, parentResourcePrimaryKey, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -2653,22 +2681,22 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration
 	 * @throws NoSuchRegistrationException if a matching registration could not be found
 	 */
 	@Override
 	public Registration findByChildArticleRegistrations_Last(
-			long groupId, long parentArticleId,
+			long groupId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
 		Registration registration = fetchByChildArticleRegistrations_Last(
-			groupId, parentArticleId, orderByComparator);
+			groupId, parentResourcePrimaryKey, orderByComparator);
 
 		if (registration != null) {
 			return registration;
@@ -2681,8 +2709,8 @@ public class RegistrationPersistenceImpl
 		msg.append("groupId=");
 		msg.append(groupId);
 
-		msg.append(", parentArticleId=");
-		msg.append(parentArticleId);
+		msg.append(", parentResourcePrimaryKey=");
+		msg.append(parentResourcePrimaryKey);
 
 		msg.append("}");
 
@@ -2690,26 +2718,28 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the last registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the last registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching registration, or <code>null</code> if a matching registration could not be found
 	 */
 	@Override
 	public Registration fetchByChildArticleRegistrations_Last(
-		long groupId, long parentArticleId,
+		long groupId, long parentResourcePrimaryKey,
 		OrderByComparator<Registration> orderByComparator) {
 
-		int count = countByChildArticleRegistrations(groupId, parentArticleId);
+		int count = countByChildArticleRegistrations(
+			groupId, parentResourcePrimaryKey);
 
 		if (count == 0) {
 			return null;
 		}
 
 		List<Registration> list = findByChildArticleRegistrations(
-			groupId, parentArticleId, count - 1, count, orderByComparator);
+			groupId, parentResourcePrimaryKey, count - 1, count,
+			orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -2719,18 +2749,18 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the registrations before and after the current registration in the ordered set where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param registrationId the primary key of the current registration
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next registration
 	 * @throws NoSuchRegistrationException if a registration with the primary key could not be found
 	 */
 	@Override
 	public Registration[] findByChildArticleRegistrations_PrevAndNext(
-			long registrationId, long groupId, long parentArticleId,
+			long registrationId, long groupId, long parentResourcePrimaryKey,
 			OrderByComparator<Registration> orderByComparator)
 		throws NoSuchRegistrationException {
 
@@ -2744,13 +2774,13 @@ public class RegistrationPersistenceImpl
 			Registration[] array = new RegistrationImpl[3];
 
 			array[0] = getByChildArticleRegistrations_PrevAndNext(
-				session, registration, groupId, parentArticleId,
+				session, registration, groupId, parentResourcePrimaryKey,
 				orderByComparator, true);
 
 			array[1] = registration;
 
 			array[2] = getByChildArticleRegistrations_PrevAndNext(
-				session, registration, groupId, parentArticleId,
+				session, registration, groupId, parentResourcePrimaryKey,
 				orderByComparator, false);
 
 			return array;
@@ -2765,8 +2795,8 @@ public class RegistrationPersistenceImpl
 
 	protected Registration getByChildArticleRegistrations_PrevAndNext(
 		Session session, Registration registration, long groupId,
-		long parentArticleId, OrderByComparator<Registration> orderByComparator,
-		boolean previous) {
+		long parentResourcePrimaryKey,
+		OrderByComparator<Registration> orderByComparator, boolean previous) {
 
 		StringBundler query = null;
 
@@ -2784,7 +2814,7 @@ public class RegistrationPersistenceImpl
 		query.append(_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_GROUPID_2);
 
 		query.append(
-			_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2);
+			_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -2857,7 +2887,7 @@ public class RegistrationPersistenceImpl
 
 		qPos.add(groupId);
 
-		qPos.add(parentArticleId);
+		qPos.add(parentResourcePrimaryKey);
 
 		if (orderByComparator != null) {
 			for (Object orderByConditionValue :
@@ -2878,18 +2908,18 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Removes all the registrations where groupId = &#63; and parentArticleId = &#63; from the database.
+	 * Removes all the registrations where groupId = &#63; and parentResourcePrimaryKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 */
 	@Override
 	public void removeByChildArticleRegistrations(
-		long groupId, long parentArticleId) {
+		long groupId, long parentResourcePrimaryKey) {
 
 		for (Registration registration :
 				findByChildArticleRegistrations(
-					groupId, parentArticleId, QueryUtil.ALL_POS,
+					groupId, parentResourcePrimaryKey, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
 			remove(registration);
@@ -2897,19 +2927,19 @@ public class RegistrationPersistenceImpl
 	}
 
 	/**
-	 * Returns the number of registrations where groupId = &#63; and parentArticleId = &#63;.
+	 * Returns the number of registrations where groupId = &#63; and parentResourcePrimaryKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param parentArticleId the parent article ID
+	 * @param parentResourcePrimaryKey the parent resource primary key
 	 * @return the number of matching registrations
 	 */
 	@Override
 	public int countByChildArticleRegistrations(
-		long groupId, long parentArticleId) {
+		long groupId, long parentResourcePrimaryKey) {
 
 		FinderPath finderPath = _finderPathCountByChildArticleRegistrations;
 
-		Object[] finderArgs = new Object[] {groupId, parentArticleId};
+		Object[] finderArgs = new Object[] {groupId, parentResourcePrimaryKey};
 
 		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
 
@@ -2921,7 +2951,7 @@ public class RegistrationPersistenceImpl
 			query.append(_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_GROUPID_2);
 
 			query.append(
-				_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2);
+				_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2);
 
 			String sql = query.toString();
 
@@ -2936,7 +2966,7 @@ public class RegistrationPersistenceImpl
 
 				qPos.add(groupId);
 
-				qPos.add(parentArticleId);
+				qPos.add(parentResourcePrimaryKey);
 
 				count = (Long)q.uniqueResult();
 
@@ -2960,8 +2990,8 @@ public class RegistrationPersistenceImpl
 			"registration.groupId = ? AND ";
 
 	private static final String
-		_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTARTICLEID_2 =
-			"registration.parentArticleId = ?";
+		_FINDER_COLUMN_CHILDARTICLEREGISTRATIONS_PARENTRESOURCEPRIMARYKEY_2 =
+			"registration.parentResourcePrimaryKey = ?";
 
 	public RegistrationPersistenceImpl() {
 		setModelClass(Registration.class);
@@ -3212,7 +3242,7 @@ public class RegistrationPersistenceImpl
 
 			args = new Object[] {
 				registrationModelImpl.getGroupId(),
-				registrationModelImpl.getArticleId()
+				registrationModelImpl.getResourcePrimaryKey()
 			};
 
 			finderCache.removeResult(
@@ -3223,7 +3253,7 @@ public class RegistrationPersistenceImpl
 			args = new Object[] {
 				registrationModelImpl.getGroupId(),
 				registrationModelImpl.getUserId(),
-				registrationModelImpl.getArticleId()
+				registrationModelImpl.getResourcePrimaryKey()
 			};
 
 			finderCache.removeResult(
@@ -3235,7 +3265,7 @@ public class RegistrationPersistenceImpl
 			args = new Object[] {
 				registrationModelImpl.getGroupId(),
 				registrationModelImpl.getUserId(),
-				registrationModelImpl.getParentArticleId()
+				registrationModelImpl.getParentResourcePrimaryKey()
 			};
 
 			finderCache.removeResult(
@@ -3246,7 +3276,7 @@ public class RegistrationPersistenceImpl
 
 			args = new Object[] {
 				registrationModelImpl.getGroupId(),
-				registrationModelImpl.getParentArticleId()
+				registrationModelImpl.getParentResourcePrimaryKey()
 			};
 
 			finderCache.removeResult(
@@ -3291,7 +3321,7 @@ public class RegistrationPersistenceImpl
 
 				Object[] args = new Object[] {
 					registrationModelImpl.getOriginalGroupId(),
-					registrationModelImpl.getOriginalArticleId()
+					registrationModelImpl.getOriginalResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3302,7 +3332,7 @@ public class RegistrationPersistenceImpl
 
 				args = new Object[] {
 					registrationModelImpl.getGroupId(),
-					registrationModelImpl.getArticleId()
+					registrationModelImpl.getResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3319,7 +3349,7 @@ public class RegistrationPersistenceImpl
 				Object[] args = new Object[] {
 					registrationModelImpl.getOriginalGroupId(),
 					registrationModelImpl.getOriginalUserId(),
-					registrationModelImpl.getOriginalArticleId()
+					registrationModelImpl.getOriginalResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3331,7 +3361,7 @@ public class RegistrationPersistenceImpl
 				args = new Object[] {
 					registrationModelImpl.getGroupId(),
 					registrationModelImpl.getUserId(),
-					registrationModelImpl.getArticleId()
+					registrationModelImpl.getResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3348,7 +3378,7 @@ public class RegistrationPersistenceImpl
 				Object[] args = new Object[] {
 					registrationModelImpl.getOriginalGroupId(),
 					registrationModelImpl.getOriginalUserId(),
-					registrationModelImpl.getOriginalParentArticleId()
+					registrationModelImpl.getOriginalParentResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3360,7 +3390,7 @@ public class RegistrationPersistenceImpl
 				args = new Object[] {
 					registrationModelImpl.getGroupId(),
 					registrationModelImpl.getUserId(),
-					registrationModelImpl.getParentArticleId()
+					registrationModelImpl.getParentResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3376,7 +3406,7 @@ public class RegistrationPersistenceImpl
 
 				Object[] args = new Object[] {
 					registrationModelImpl.getOriginalGroupId(),
-					registrationModelImpl.getOriginalParentArticleId()
+					registrationModelImpl.getOriginalParentResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3387,7 +3417,7 @@ public class RegistrationPersistenceImpl
 
 				args = new Object[] {
 					registrationModelImpl.getGroupId(),
-					registrationModelImpl.getParentArticleId()
+					registrationModelImpl.getParentResourcePrimaryKey()
 				};
 
 				finderCache.removeResult(
@@ -3871,7 +3901,7 @@ public class RegistrationPersistenceImpl
 			"findByArticleRegistrations",
 			new String[] {Long.class.getName(), Long.class.getName()},
 			RegistrationModelImpl.GROUPID_COLUMN_BITMASK |
-			RegistrationModelImpl.ARTICLEID_COLUMN_BITMASK |
+			RegistrationModelImpl.RESOURCEPRIMARYKEY_COLUMN_BITMASK |
 			RegistrationModelImpl.STARTTIME_COLUMN_BITMASK);
 
 		_finderPathCountByArticleRegistrations = new FinderPath(
@@ -3906,7 +3936,7 @@ public class RegistrationPersistenceImpl
 				},
 				RegistrationModelImpl.GROUPID_COLUMN_BITMASK |
 				RegistrationModelImpl.USERID_COLUMN_BITMASK |
-				RegistrationModelImpl.ARTICLEID_COLUMN_BITMASK |
+				RegistrationModelImpl.RESOURCEPRIMARYKEY_COLUMN_BITMASK |
 				RegistrationModelImpl.STARTTIME_COLUMN_BITMASK);
 
 		_finderPathCountByUserArticleRegistrations = new FinderPath(
@@ -3943,7 +3973,7 @@ public class RegistrationPersistenceImpl
 				},
 				RegistrationModelImpl.GROUPID_COLUMN_BITMASK |
 				RegistrationModelImpl.USERID_COLUMN_BITMASK |
-				RegistrationModelImpl.PARENTARTICLEID_COLUMN_BITMASK |
+				RegistrationModelImpl.PARENTRESOURCEPRIMARYKEY_COLUMN_BITMASK |
 				RegistrationModelImpl.STARTTIME_COLUMN_BITMASK);
 
 		_finderPathCountByUserChildArticleRegistrations = new FinderPath(
@@ -3976,7 +4006,7 @@ public class RegistrationPersistenceImpl
 				"findByChildArticleRegistrations",
 				new String[] {Long.class.getName(), Long.class.getName()},
 				RegistrationModelImpl.GROUPID_COLUMN_BITMASK |
-				RegistrationModelImpl.PARENTARTICLEID_COLUMN_BITMASK |
+				RegistrationModelImpl.PARENTRESOURCEPRIMARYKEY_COLUMN_BITMASK |
 				RegistrationModelImpl.STARTTIME_COLUMN_BITMASK);
 
 		_finderPathCountByChildArticleRegistrations = new FinderPath(

--- a/modules/registration-service/registration-service-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/registration-service/registration-service-service/src/main/resources/META-INF/module-hbm.xml
@@ -10,10 +10,10 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="articleId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="resourcePrimaryKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userPreferences" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="startTime" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="endTime" type="org.hibernate.type.TimestampType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="parentArticleId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="parentResourcePrimaryKey" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 	</class>
 </hibernate-mapping>

--- a/modules/registration-service/registration-service-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/registration-service/registration-service-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -6,12 +6,12 @@
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="userId" type="long" />
-		<field name="articleId" type="long" />
+		<field name="resourcePrimaryKey" type="long" />
 		<field name="userPreferences" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>
 		<field name="startTime" type="Date" />
 		<field name="endTime" type="Date" />
-		<field name="parentArticleId" type="long" />
+		<field name="parentResourcePrimaryKey" type="long" />
 	</model>
 </model-hints>

--- a/modules/registration-service/registration-service-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/registration-service/registration-service-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,4 +1,4 @@
-create index IX_7B15BB on Registrations_Registration (groupId, articleId);
-create index IX_6EAC14B1 on Registrations_Registration (groupId, parentArticleId);
-create index IX_80ABFB41 on Registrations_Registration (groupId, userId, articleId);
-create index IX_AE603DB7 on Registrations_Registration (groupId, userId, parentArticleId);
+create index IX_EF4176CF on Registrations_Registration (groupId, parentResourcePrimaryKey);
+create index IX_CAA20105 on Registrations_Registration (groupId, resourcePrimaryKey);
+create index IX_96E41489 on Registrations_Registration (groupId, userId, parentResourcePrimaryKey);
+create index IX_1113F23F on Registrations_Registration (groupId, userId, resourcePrimaryKey);

--- a/modules/registration-service/registration-service-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/registration-service/registration-service-service/src/main/resources/META-INF/sql/tables.sql
@@ -3,9 +3,9 @@ create table Registrations_Registration (
 	groupId LONG,
 	companyId LONG,
 	userId LONG,
-	articleId LONG,
+	resourcePrimaryKey LONG,
 	userPreferences STRING null,
 	startTime DATE null,
 	endTime DATE null,
-	parentArticleId LONG
+	parentResourcePrimaryKey LONG
 );

--- a/modules/registration-service/registration-service-service/src/main/resources/service.properties
+++ b/modules/registration-service/registration-service-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=Registrations
-    build.number=16
-    build.date=1591701757066
+    build.number=17
+    build.date=1591710197101

--- a/modules/rest/src/main/java/nl/deltares/services/rest/registration/UserRegistrationService.java
+++ b/modules/rest/src/main/java/nl/deltares/services/rest/registration/UserRegistrationService.java
@@ -42,13 +42,13 @@ public class UserRegistrationService {
     }
 
     @POST
-    @Path("/register/{siteId}/{registrationId}")
+    @Path("/register/{siteId}/{articleId}")
     @Consumes("application/json")
     public Response register(@Context HttpServletRequest request,
-                         @PathParam("siteId") long siteId, @PathParam("registrationId") long registrationId, String jsonProperties) throws Exception {
+                         @PathParam("siteId") long siteId, @PathParam("articleId") long articleId, String jsonProperties) throws Exception {
 
         User user = getRemoteUser(request);
-        Registration registration = getRegistrationArticle(siteId, registrationId);
+        Registration registration = getRegistrationArticle(siteId, articleId);
 
         try {
             registrationUtils.registerUser(user, registration, jsonProperties);
@@ -57,23 +57,24 @@ public class UserRegistrationService {
             LOG.warn(msg);
             return Response.serverError().entity(msg).type(MediaType.APPLICATION_JSON).build();
         }
-        return Response.accepted(String.format("User %s registered for '%s'", user.getEmailAddress(), registration.getTitle())).type(MediaType.APPLICATION_JSON).build();
+
+        return Response.accepted("User registered for " + registration.getTitle()).type(MediaType.APPLICATION_JSON).build();
     }
 
     @DELETE
-    @Path("/register/{siteId}/{registrationId}")
+    @Path("/register/{siteId}/{articleId}")
     @Consumes("application/json")
     public Response unRegister(@Context HttpServletRequest request,
-                             @PathParam("siteId") long siteId, @PathParam("registrationId") long registrationId) throws Exception {
+                             @PathParam("siteId") long siteId, @PathParam("articleId") long articleId) throws Exception {
         User user = getRemoteUser(request);
 
-        Registration registration = getRegistrationArticle(siteId, registrationId);
+        Registration registration = getRegistrationArticle(siteId, articleId);
         registrationUtils.unRegisterUser(user, registration);
-        return Response.accepted(String.format("User %s un-registered for '%s'", user.getEmailAddress(), registration.getTitle())).type(MediaType.APPLICATION_JSON).build();
+        return Response.accepted("User un-registered for " + registration.getTitle()).type(MediaType.APPLICATION_JSON).build();
     }
 
-    private Registration getRegistrationArticle(long siteId, long registrationId) throws PortalException {
-        JournalArticle article = JournalArticleLocalServiceUtil.getLatestArticle(siteId, String.valueOf(registrationId));
+    private Registration getRegistrationArticle(long siteId, long articleId) throws PortalException {
+        JournalArticle article = JournalArticleLocalServiceUtil.getLatestArticle(siteId, String.valueOf(articleId));
         AbsDsdArticle registration = AbsDsdArticle.getInstance(article);
         if (! (registration instanceof Registration)){
             String msg = "Invalid registration type! Expected instance of RegistrationArticle found: " +registration.getClass().getName();
@@ -97,16 +98,9 @@ public class UserRegistrationService {
     @POST
     @Path("/info")
     @Consumes("application/json")
-    public Response setUserAttributes(@Context HttpServletRequest request, UserDetails userDetails) throws Exception {
+    public void setUserAttributes(@Context HttpServletRequest request, UserDetails userDetails) throws Exception {
         User user = getRemoteUser(request);
-        try {
-            updateUserAttributes(userDetails, user);
-        } catch (LiferayRestException e) {
-            String msg = "Error Updating user: " + e.getMessage();
-            LOG.warn(msg);
-            return Response.serverError().entity(msg).type(MediaType.APPLICATION_JSON).build();
-        }
-        return Response.accepted(String.format("User %s has been updated!", user.getEmailAddress())).type(MediaType.APPLICATION_JSON).build();
+        updateUserAttributes(userDetails, user);
     }
 
     private UserDetails getUserDetails(User user) throws LiferayRestException {


### PR DESCRIPTION
In registration table changed from articleId to resourcePrimaryKey. Because when deleting an article the primary key changes and it is no longer possible to delete the related records in the registrations table.